### PR TITLE
Set versioneer tag_prefix to "v".

### DIFF
--- a/bmi_wrap/_version.py
+++ b/bmi_wrap/_version.py
@@ -41,7 +41,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "bmi_wrap-"
     cfg.versionfile_source = "bmi_wrap/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ VCS = git
 style = pep440
 versionfile_source = bmi_wrapj/_version.py
 versionfile_build = bmi_wrap/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = bmi_wrap-


### PR DESCRIPTION
This pull request fixes the version number determined by versioneer. Our tags always begin with the letter "v", which we don't want included in the actual version string.