### PR TITLE
Add bmi-render command

### DIFF
--- a/bmi_wrap/__init__.py
+++ b/bmi_wrap/__init__.py
@@ -1,4 +1,5 @@
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/bmi_wrap/cli/main.py
+++ b/bmi_wrap/cli/main.py
@@ -8,19 +8,17 @@ from .. import __version__
 
 def generate_parser():
     p = argparse.ArgumentParser(
-        description='command-line tool for doing CSDMS related things.',
-        fromfile_prefix_chars='@',
+        description="command-line tool for doing CSDMS related things.",
+        fromfile_prefix_chars="@",
     )
     p.add_argument(
-        '-V', '--version',
-        action='version',
-        version='csdms {0}'.format(__version__),
-        help='Show the csdms version number and exit.'
+        "-V",
+        "--version",
+        action="version",
+        version="csdms {0}".format(__version__),
+        help="Show the csdms version number and exit.",
     )
-    sub_parsers = p.add_subparsers(
-        metavar='command',
-        dest='cmd',
-    )
+    sub_parsers = p.add_subparsers(metavar="command", dest="cmd")
     sub_parsers.required = True
 
     configure_parser_wrap(sub_parsers)
@@ -29,15 +27,13 @@ def generate_parser():
 
 
 class AppendKeyValueAction(argparse.Action):
-
     def __call__(self, parser, namespace, values, option_string):
-        getattr(namespace, 'define_macros').append(values.split('='))
+        getattr(namespace, "define_macros").append(values.split("="))
 
 
 class SetDefaultsAction(argparse.Action):
-
     def __call__(self, parser, namespace, values, option_string):
-        with open(values, 'r') as fp:
+        with open(values, "r") as fp:
             defaults = yaml.load(fp.read())
         parser.set_defaults(**defaults)
 
@@ -45,122 +41,84 @@ class SetDefaultsAction(argparse.Action):
 def configure_parser_wrap(sub_parsers=None):
     help = "Wrap a shared library that implements a BMI."
 
-    example = textwrap.dedent("""
+    example = textwrap.dedent(
+        """
 
     Examples:
 
     csdms wrap --language=c libbmi.so
 
-    """)
+    """
+    )
     if sub_parsers is None:
         p = argparse.ArgumentParser(
-            description=help,
-            fromfile_prefix_chars='@',
-            epilog=example,
+            description=help, fromfile_prefix_chars="@", epilog=example
         )
     else:
-        p = sub_parsers.add_parser(
-            'wrap',
-            help=help,
-            description=help,
-            epilog=example,
-        )
+        p = sub_parsers.add_parser("wrap", help=help, description=help, epilog=example)
+    p.add_argument("lib", help="library to wrap")
+    p.add_argument("--output-dir", default=".", help="folder to dump files to")
     p.add_argument(
-        'lib',
-        help='library to wrap',
+        "--clobber", action="store_true", help="clobber folder if it already exists"
+    )
+    p.add_argument("--prompt", action="store_true", help="prompt user for input")
+    p.add_argument("--compile", action="store_true", help="build the extension module")
+    p.add_argument("--name", help="name of the model")
+    p.add_argument(
+        "--language", help="language of the library", choices=["c", "c++"], default="c"
     )
     p.add_argument(
-        '--output-dir',
-        default='.',
-        help='folder to dump files to',
-    )
-    p.add_argument(
-        '--clobber',
-        action='store_true',
-        help='clobber folder if it already exists',
-    )
-    p.add_argument(
-        '--prompt',
-        action='store_true',
-        help='prompt user for input',
-    )
-    p.add_argument(
-        '--compile',
-        action='store_true',
-        help='build the extension module',
-    )
-    p.add_argument(
-        '--name',
-        help='name of the model',
-    )
-    p.add_argument(
-        '--language',
-        help='language of the library',
-        choices=['c', 'c++', ],
-        default='c',
-    )
-    p.add_argument(
-        '-l', '--libraries',
-        dest='libraries',
+        "-l",
+        "--libraries",
+        dest="libraries",
         default=[],
-        action='append',
-        help='library names to link against',
+        action="append",
+        help="library names to link against",
     )
     p.add_argument(
-        '-L', '--library-dirs',
+        "-L",
+        "--library-dirs",
         default=[],
-        dest='library_dirs',
-        action='append',
-        help='directories to search for C/C++ libraries at link time',
+        dest="library_dirs",
+        action="append",
+        help="directories to search for C/C++ libraries at link time",
     )
     p.add_argument(
-        '-I', '--include-dirs',
+        "-I",
+        "--include-dirs",
         default=[],
-        dest='include_dirs',
-        action='append',
-        help='directories to search for C/C++ header files',
+        dest="include_dirs",
+        action="append",
+        help="directories to search for C/C++ header files",
     )
     p.add_argument(
-        '--extra-compile-args',
+        "--extra-compile-args",
         default=[],
-        action='append',
-        help='extra args to use when compiling',
+        action="append",
+        help="extra args to use when compiling",
     )
     p.add_argument(
-        '-D', '--define-macros',
+        "-D",
+        "--define-macros",
         default=[],
         # action=AppendKeyValueAction,
-        action='append',
-        help='macros to define explicitly',
+        action="append",
+        help="macros to define explicitly",
     )
     p.add_argument(
-        '-U', '--undef-macros',
+        "-U",
+        "--undef-macros",
         default=[],
-        dest='undef_macros',
-        action='append',
-        help='macros to undefine explicitly',
+        dest="undef_macros",
+        action="append",
+        help="macros to undefine explicitly",
     )
-    p.add_argument(
-        '--module-name',
-        default=None,
-        help='name to use for the new module',
-    )
-    p.add_argument(
-        '--class-name',
-        default=None,
-        help='name to use for the class',
-    )
-    p.add_argument(
-        '--bmi-include',
-        default=None,
-        help='bmi include file',
-    )
-    p.add_argument(
-        '--bmi-register',
-        default=None,
-        help='bmi registration function',
-    )
+    p.add_argument("--module-name", default=None, help="name to use for the new module")
+    p.add_argument("--class-name", default=None, help="name to use for the class")
+    p.add_argument("--bmi-include", default=None, help="bmi include file")
+    p.add_argument("--bmi-register", default=None, help="bmi registration function")
     from .main_wrap import execute
+
     p.set_defaults(func=execute)
 
     return p

--- a/bmi_wrap/cli/main_render.py
+++ b/bmi_wrap/cli/main_render.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+import os
+
+import click
+import yaml
+from cookiecutter.main import cookiecutter
+from scripting.contexts import cd
+from scripting.unix import system
+
+from .. import __version__
+
+
+@click.command()
+@click.version_option(version=__version__)
+@click.option("--compile", is_flag=True, help="compile the extension module")
+@click.option("--clobber", is_flag=True, help="clobber folder if it already exists")
+@click.option(
+    "--template",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+    ),
+    help="Location of cookiecutter template",
+)
+@click.argument("meta", type=click.File(mode="r"))
+@click.argument(
+    "output",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, resolve_path=True),
+)
+def main(meta, output, compile, clobber, template):
+
+    config = yaml.load(meta)
+
+    cookiecutter_config = {
+        "full_name": config["info"]["plugin_author"],
+        "github_username": config["info"]["github_username"],
+        "module_name": config["pymt"]["module_name"],
+        "bmi_include": config["library"]["bmi_include"],
+        "bmi_register": config["library"]["entry_point"],
+        "class_name": config["pymt"]["class_name"],
+        "language": config["library"]["language"],
+        "undef_macros": ",".join(config["build"]["undef_macros"]),
+        "define_macros": ",".join(config["build"]["define_macros"]),
+        "libraries": ",".join(config["build"]["libraries"]),
+        "library_dirs": ",".join(config["build"]["library_dirs"]),
+        "include_dirs": ",".join(config["build"]["include_dirs"]),
+        "extra_compile_args": ",".join(config["build"]["extra_compile_args"]),
+        "open_source_license": config["info"]["plugin_license"],
+        "project_short_description": config["info"]["summary"],
+    }
+
+    cookiecutter(
+        template,
+        extra_context=cookiecutter_config,
+        output_dir=output,
+        no_input=True,
+        overwrite_if_exists=clobber,
+    )
+
+    path = os.path.join(output, "pymt_{}".format(config["pymt"]["module_name"]))
+    click.secho("Your pymt plugin can be found at {}".format(path), fg="green")
+
+    if compile:
+        with cd(path):
+            system(["versioneer", "install"])
+            system(["python", "setup.py", "develop"])
+    else:
+        click.secho("Build with:", fg="white")
+        click.secho("    $ cd {0}".format(path), fg="white")
+        click.secho("    $ versioneer install", fg="white")
+        click.secho("    $ python setup.py develop", fg="white")
+
+
+if __name__ == "__main__":
+    main(auto_envvar_prefix="BMI_WRAP")

--- a/bmi_wrap/cli/main_render.py
+++ b/bmi_wrap/cli/main_render.py
@@ -1,13 +1,197 @@
 #! /usr/bin/env python
 import os
+import re
+from collections import OrderedDict
 
 import click
+import six
 import yaml
 from cookiecutter.main import cookiecutter
+
 from scripting.contexts import cd
 from scripting.unix import system
 
 from .. import __version__
+
+
+_TEMPLATE_URI = "http://github.com/mcflugen/cookiecutter-bmi-wrap"
+
+
+def setup_yaml_with_canonical_dict():
+    """ https://stackoverflow.com/a/8661021 """
+    yaml.add_representer(
+        OrderedDict,
+        lambda self, data: self.represent_mapping(
+            "tag:yaml.org,2002:map", data.items()
+        ),
+        Dumper=yaml.SafeDumper,
+    )
+
+    def repr_ordered_dict(self, data):
+        return self.represent_mapping("tag:yaml.org,2002:map", data.items())
+
+    yaml.add_representer(dict, repr_ordered_dict, Dumper=yaml.SafeDumper)
+
+    def repr_dict(self, data):
+        return self.represent_mapping(
+            "tag:yaml.org,2002:map", sorted(data.items(), key=lambda t: t[0])
+        )
+
+    yaml.add_representer(dict, repr_dict, Dumper=yaml.SafeDumper)
+
+    # https://stackoverflow.com/a/45004464
+    def repr_str(dumper, data):
+        if "\n" in data:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+        return dumper.represent_str(data)
+
+    yaml.add_representer(str, repr_str, Dumper=yaml.SafeDumper)
+
+    def repr_tuple(dumper, data):
+        return dumper.represent_sequence("tag:yaml.org,2002:seq", list(data))
+
+    yaml.add_representer(tuple, repr_tuple, Dumper=yaml.SafeDumper)
+
+    # loader = yaml.SafeLoader
+    yaml.add_implicit_resolver(
+        u"tag:yaml.org,2002:float",
+        re.compile(
+            u"""^(?:
+         [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+        |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
+        |\\.[0-9_]+(?:[eE][-+][0-9]+)?
+        |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*
+        |[-+]?\\.(?:inf|Inf|INF)
+        |\\.(?:nan|NaN|NAN))$""",
+            re.X,
+        ),
+        list(u"-+0123456789."),
+    )
+
+
+setup_yaml_with_canonical_dict()
+
+
+class BmiWrapError(Exception):
+    def __init__(self, message):
+        self._message = message
+
+    def __str__(self):
+        return self._message
+
+
+class ValidationError(BmiWrapError):
+
+    pass
+
+
+class RenderError(BmiWrapError):
+
+    pass
+
+
+def validate_meta(meta):
+    missing_sections = set(PluginMetadata.REQUIRED) - set(meta)
+    if missing_sections:
+        raise ValidationError(
+            "missing required sections {0}".format(", ".join(missing_sections))
+        )
+
+    for section, values in PluginMetadata.REQUIRED.items():
+        missing_values = set(values) - set(meta[section])
+        if missing_values:
+            raise ValidationError(
+                "missing required values {0}".format(", ".join(missing_values))
+            )
+
+    def _is_iterable_of_strings(value):
+        if isinstance(value, six.string_types):
+            return False
+        for item in value:
+            if not isinstance(item, six.string_types):
+                return False
+        return True
+
+    for key, value in meta["build"].items():
+        if not _is_iterable_of_strings(value):
+            raise ValidationError("not an iterable of strings: build->{0}".format(key))
+
+    for value in meta["build"]["define_macros"]:
+        if len(value.split("=")) != 2:
+            raise ValidationError(
+                "build->define_macros must be of the form 'key=value'"
+            )
+
+
+class PluginMetadata(object):
+    REQUIRED = {
+        "library": ("name", "language", "entry_point"),
+        "plugin": ("name", "module", "class", "conda_package"),
+        "info": ("plugin_author", "github_username", "plugin_license", "summary"),
+    }
+
+    def __init__(self, filepath):
+        self._meta = PluginMetadata.norm(yaml.load(filepath))
+        validate_meta(self._meta)
+
+    def get(self, section, value):
+        return self._meta[section][value]
+
+    @staticmethod
+    def norm(config):
+        return {
+            "library": {
+                "name": config["library"]["name"],
+                "language": config["library"]["language"],
+                "bmi_include": config["library"]["bmi_include"],
+                "entry_point": config["library"]["entry_point"],
+            },
+            "build": {
+                "undef_macros": config["build"].get("undef_macros", []),
+                "define_macros": config["build"].get("define_macros", []),
+                "libraries": config["build"].get("libraries", []),
+                "library_dirs": config["build"].get("library_dirs", []),
+                "include_dirs": config["build"].get("include_dirs", []),
+                "extra_compile_args": config["build"].get("extra_compile_args", []),
+            },
+            "plugin": {
+                "name": config["plugin"]["name"],
+                "module": config["plugin"]["module"],
+                "class": config["plugin"]["class"],
+                "conda_package": config["plugin"]["conda_package"],
+            },
+            "info": {
+                "plugin_author": config["info"]["plugin_author"],
+                "github_username": config["info"]["github_username"],
+                "plugin_license": config["info"]["plugin_license"],
+                "summary": config["info"]["summary"],
+            },
+        }
+
+    def dump(self, fp):
+        yaml.safe_dump(self._meta, fp, default_flow_style=False)
+
+    def as_cookiecutter_context(self):
+        return {
+            "full_name": self._meta["info"]["plugin_author"],
+            "github_username": self._meta["info"]["github_username"],
+            "plugin_name": self._meta["plugin"]["name"],
+            "plugin_name": self._meta["plugin"]["module"],
+            "plugin_class": self._meta["plugin"]["class"],
+            "plugin_conda_package": self._meta["plugin"]["conda_package"],
+            "bmi_include": self._meta["library"]["bmi_include"],
+            "bmi_register": self._meta["library"]["entry_point"],
+            # "class_name": self._meta["pymt"]["class_name"],
+            "language": self._meta["library"]["language"],
+            "undef_macros": ",".join(self._meta["build"]["undef_macros"]),
+            "define_macros": ",".join(self._meta["build"]["define_macros"]),
+            "libraries": ",".join(self._meta["build"]["libraries"]),
+            "library_dirs": ",".join(self._meta["build"]["library_dirs"]),
+            "include_dirs": ",".join(self._meta["build"]["include_dirs"]),
+            "extra_compile_args": ",".join(self._meta["build"]["extra_compile_args"]),
+            "open_source_license": self._meta["info"]["plugin_license"],
+            "project_short_description": self._meta["info"]["summary"],
+        }
 
 
 @click.command()
@@ -15,15 +199,20 @@ from .. import __version__
 @click.option("--compile", is_flag=True, help="compile the extension module")
 @click.option("--clobber", is_flag=True, help="clobber folder if it already exists")
 @click.option(
-    "--template",
-    type=click.Path(
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        writable=False,
-        readable=True,
-        resolve_path=True,
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help=(
+        "Don't emit non-error messages to stderr. Errors are still emitted, "
+        "silence those with 2>/dev/null."
     ),
+)
+@click.option(
+    "-v", "--verbose", is_flag=True, help="Also emit status messages to stderr."
+)
+@click.option(
+    "--template",
+    default="http://github.com/mcflugen/cookiecutter-bmi-wrap",
     help="Location of cookiecutter template",
 )
 @click.argument("meta", type=click.File(mode="r"))
@@ -31,48 +220,61 @@ from .. import __version__
     "output",
     type=click.Path(file_okay=False, dir_okay=True, writable=True, resolve_path=True),
 )
-def main(meta, output, compile, clobber, template):
+def main(meta, output, compile, clobber, template, quiet, verbose):
 
-    config = yaml.load(meta)
+    config = PluginMetadata(meta)
 
-    cookiecutter_config = {
-        "full_name": config["info"]["plugin_author"],
-        "github_username": config["info"]["github_username"],
-        "module_name": config["pymt"]["module_name"],
-        "bmi_include": config["library"]["bmi_include"],
-        "bmi_register": config["library"]["entry_point"],
-        "class_name": config["pymt"]["class_name"],
-        "language": config["library"]["language"],
-        "undef_macros": ",".join(config["build"]["undef_macros"]),
-        "define_macros": ",".join(config["build"]["define_macros"]),
-        "libraries": ",".join(config["build"]["libraries"]),
-        "library_dirs": ",".join(config["build"]["library_dirs"]),
-        "include_dirs": ",".join(config["build"]["include_dirs"]),
-        "extra_compile_args": ",".join(config["build"]["extra_compile_args"]),
-        "open_source_license": config["info"]["plugin_license"],
-        "project_short_description": config["info"]["summary"],
-    }
+    if not quiet:
+        click.secho("reading template from {}".format(template), err=True)
 
-    cookiecutter(
-        template,
-        extra_context=cookiecutter_config,
+    path = render_plugin_repo(
+        config.as_cookiecutter_context(),
         output_dir=output,
-        no_input=True,
-        overwrite_if_exists=clobber,
+        template=template,
+        clobber=clobber,
     )
 
-    path = os.path.join(output, "pymt_{}".format(config["pymt"]["module_name"]))
-    click.secho("Your pymt plugin can be found at {}".format(path), fg="green")
+    with open(os.path.join(path, "plugin.yaml"), "w") as fp:
+        config.dump(fp)
+
+    if not quiet:
+        click.secho("Your pymt plugin can be found at {}".format(path), fg="green")
 
     if compile:
         with cd(path):
             system(["versioneer", "install"])
             system(["python", "setup.py", "develop"])
-    else:
-        click.secho("Build with:", fg="white")
+    elif not quiet:
+        click.secho("Skipping compile step. You can do this later with:", fg="white")
         click.secho("    $ cd {0}".format(path), fg="white")
         click.secho("    $ versioneer install", fg="white")
         click.secho("    $ python setup.py develop", fg="white")
+
+    if not quiet:
+        click.secho(
+            "Don't forget to drop model metadata files into {0}".format(
+                os.path.join(path, "meta")
+            ),
+            fg="green",
+        )
+
+
+def render_plugin_repo(context, output_dir=".", clobber=False, template=None):
+    template = template or _TEMPLATE_URI
+
+    cookiecutter(
+        template,
+        extra_context=context,
+        output_dir=output_dir,
+        no_input=True,
+        overwrite_if_exists=clobber,
+    )
+
+    path = os.path.join(output_dir, "pymt_{}".format(context["plugin_name"]))
+    if not os.path.isdir(path):
+        raise RenderError("error creating {}".format(path))
+
+    return path
 
 
 if __name__ == "__main__":

--- a/bmi_wrap/cli/main_wrap.py
+++ b/bmi_wrap/cli/main_wrap.py
@@ -1,18 +1,16 @@
 #! /usr/bin/env python
-from __future__ import print_function
-
 import os
 
-from scripting.prompting import status
 from scripting.contexts import cd
 from scripting.unix import system
 
+from .. import __version__
 from ..wrap import render
 
 
 def get_library_name(path):
     fname, _ = os.path.splitext(os.path.basename(path))
-    if fname.startswith('lib'):
+    if fname.startswith("lib"):
         fname = fname[3:]
 
     return fname
@@ -32,11 +30,11 @@ def pop_if_none(context):
     return context
 
 
-def join_lists(context, delim=' '):
+def join_lists(context, delim=" "):
     for arg, value in context.items():
         if isinstance(value, list):
             try:
-                context[arg] = ','.join(value)
+                context[arg] = ",".join(value)
             except TypeError:
                 pass
     return context
@@ -45,17 +43,22 @@ def join_lists(context, delim=' '):
 def execute(args):
     context = args.__dict__
 
-    context['libraries'] = append_if_missing(get_library_name(args.lib),
-                                             items=args.libraries)
+    context["libraries"] = append_if_missing(
+        get_library_name(args.lib), items=args.libraries
+    )
 
     pop_if_none(context)
-    join_lists(context, delim=',')
+    join_lists(context, delim=",")
 
-    path = render(args.language, context, output_dir=args.output_dir,
-                 overwrite_if_exists=args.clobber)
+    path = render(
+        args.language,
+        context,
+        output_dir=args.output_dir,
+        overwrite_if_exists=args.clobber,
+    )
     if args.compile:
         with cd(path):
-            system(['python', 'setup.py', 'develop'])
+            system(["python", "setup.py", "develop"])
 
 
 def main():

--- a/bmi_wrap/wrap.py
+++ b/bmi_wrap/wrap.py
@@ -7,12 +7,16 @@ import pkg_resources
 from cookiecutter.main import cookiecutter
 
 
-def render(language, context=None, output_dir=None, no_input=True,
-           overwrite_if_exists=False):
+def render(
+    language, context=None, output_dir=None, no_input=True, overwrite_if_exists=False
+):
     # template = pkg_resources.resource_filename(
     #     __name__, os.path.join('templates', language))
-    template = pkg_resources.resource_filename(
-        __name__, os.path.join('templates'))
-    return cookiecutter(template, overwrite_if_exists=overwrite_if_exists,
-                        no_input=no_input, output_dir=output_dir,
-                        extra_context=context)
+    template = pkg_resources.resource_filename(__name__, os.path.join("templates"))
+    return cookiecutter(
+        template,
+        overwrite_if_exists=overwrite_if_exists,
+        no_input=no_input,
+        output_dir=output_dir,
+        extra_context=context,
+    )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "jinja2",
     "cookiecutter",
     "six",
-    "scripting",
+    # "scripting",
 ]
 
 
@@ -35,6 +35,7 @@ setup(
     entry_points={
         'console_scripts': [
             'bmi-wrap=bmi_wrap.cli.main_wrap:main',
+            'bmi-render=bmi_wrap.cli.main_render:main',
         ],
         'bmi.plugins': [
             'bmi_wrap=bmi_wrap.cli.main:configure_parser_wrap',


### PR DESCRIPTION
This pull request adds a `bmi-render` command that renders a repository that wraps one or more BMI components into components (or plugins) that are *pymt*-compatible. Usage looks something like,
```
bmi-render plugin.yaml .
```
where `plugin.yaml` provides metadata about the component(s) to be wrapped. An example plugin.yaml file that wraps four C components,
```yaml
build:
  define_macros: []
  extra_compile_args: []
  include_dirs: []
  libraries:
  - bmi_sedflux3d
  - bmi_avulsion
  - bmi_plume
  - bmi_subside
  library_dirs: []
  undef_macros: []
info:
  github_username: mcflugen
  plugin_author: Eric Hutton
  plugin_license: MIT
  summary: PyMT plugin for sedflux
library:
  entry_point:
  - Sedflux3D=sedflux:register_bmi_sedflux3d
  - Avulsion=sedflux:register_bmi_avulsion
  - Plume=sedflux:register_bmi_plume
  - Subside=sedflux:register_bmi_subside
  language: c
plugin:
  name: sedflux
  requirements:
  - sedflux
```