### PR TITLE
Add output option to quickstart command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,7 +258,7 @@ For example the above *babel.toml* can be generated with the following,
 
 .. code:: bash
 
-  $ babelize quickstart --batch --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydrotrend --requirement=hydrotrend
+  $ babelize quickstart --batch --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydrotrend --requirement=hydrotrend --output=babel.toml
 
 ********
 Examples

--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ called *hydrotrend*.
   extra_compile_args = []
 
   [plugin]
-  name = "hydortrend"
+  name = "hydrotrend"
   requirements = [ "hydrotrend",]
 
   [info]
@@ -258,7 +258,7 @@ For example the above *babel.toml* can be generated with the following,
 
 .. code:: bash
 
-  $ babelize quickstart --batch --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydortrend --requirement=hydrotrend
+  $ babelize quickstart --batch --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydrotrend --requirement=hydrotrend
 
 ********
 Examples

--- a/README.rst
+++ b/README.rst
@@ -83,33 +83,36 @@ install *babelizer* into the current environment::
 Input file
 **********
 
-The *babelizer* requires a single, *yaml* formatted, input file that describes
-the library you would like to wrap. This file is typically called, *babel.yaml*.
-An example of a blank *babel.yaml* file,
+The *babelizer* requires a single, *toml*-formatted, input file that describes
+the library you would like to wrap. This file is typically called, *babel.toml*.
+An example of a blank *babel.toml* file,
 
-.. code:: yaml
+.. code:: toml
 
-    build:
-      define_macros: []
-      extra_compile_args: []
-      include_dirs: []
-      libraries: []
-      library_dirs: []
-      undef_macros: []
-    info:
-      github_username: pymt-lab
-      plugin_author: csdms
-      plugin_license: MIT
-      summary: ''
-    library:
-      entry_point: []
-      language: c
-    plugin:
-      name: ''
-      requirements: []
+  [library]
+  language = "c"
+  entry_point = []
 
-You can generate *babel.yaml* files using the *babelize quickstart* command.
-For example, the above *babel.yaml* was generated with,
+  [build]
+  undef_macros = []
+  define_macros = []
+  libraries = []
+  library_dirs = []
+  include_dirs = []
+  extra_compile_args = []
+
+  [plugin]
+  name = ""
+  requirements = []
+
+  [info]
+  plugin_author = "csdms"
+  github_username = "pymt-lab"
+  plugin_license = "MIT"
+  summary = ""
+
+You can generate *babel.toml* files using the *babelize quickstart* command.
+For example, the above *babel.toml* was generated with,
 
 .. code:: bash
 
@@ -163,20 +166,18 @@ A list of one or more entry points into the library.
 The following will define a Python class *Hydrotrend* that wraps the function
 *register_bmi_hydrotrend* defined in the library *bmi_hydrotrend*.
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    entry_point:
-    - Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend
+  [library]
+  entry_point = [ "Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend" ]
 
 An example of a C++ library (*bmi_child*), exposing a class *Child* (which
 implemets a BMI) might look like the following,
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    entry_point:
-    - Child=bmi_child:Child
+  [library]
+  entry_point = [ "Child=bmi_child:Child"]
 
 Library language
 ----------------
@@ -184,10 +185,10 @@ Library language
 The programming language of the library (possible values are "c", "c++",
 "fortran", and "python").
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    language: c
+  [library]
+  language = "c"
 
 Plugin section
 ==============
@@ -201,10 +202,10 @@ Name to use for the wrapped package. This is used when create the new
 package, *pymt_<plugin_name>*. For example, the following will create
 a new package, *pymt_foo*.
 
-.. code:: yaml
+.. code:: toml
 
-  plugin:
-    name: foo
+  [plugin]
+  name = "foo"
 
 Requirements
 ------------
@@ -213,47 +214,47 @@ List of packages required by the libaray being wrapped. For example, the
 following indicates that the packages *foo* and *bar* are dependencies
 for the package.
 
-.. code:: yaml
+.. code:: toml
 
-  plugin:
-    requirements:
-    - foo
-    - bar
+  [plugin]
+  requirements = [ "foo", "bar"]
 
 
-Example babel.yaml
+Example babel.toml
 ==================
 
-Below is an example of a *babel.yaml* file that describes a shared library,
+Below is an example of a *babel.toml* file that describes a shared library,
 written in C. In this example, the library, *bmi_hydrotrend*, exposes the
 function *register_bmi_hydrotrend* that implements a BMI for a component
 called *hydrotrend*.
 
-.. code:: yaml
+.. code:: toml
 
-  build:
-    define_macros: []
-    extra_compile_args: []
-    include_dirs: []
-    libraries: []
-    library_dirs: []
-    undef_macros: []
-  info:
-    github_username: pymt-lab
-    plugin_author: csdms
-    plugin_license: MIT
-    summary: PyMT plugin for hydrotrend
-  library:
-    entry_point:
-    - Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend
-    language: c
-  plugin:
-    name: hydortrend
-    requirements:
-    - hydrotrend
+  [library]
+  language = "c"
+  entry_point = [ "Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend",]
 
-You can use the *babelize quickstart* command to generate *babel.yaml* files.
-For example the above *babel.yaml* can be generated with the following,
+  [build]
+  undef_macros = []
+  define_macros = []
+  libraries = []
+  library_dirs = []
+  include_dirs = []
+  extra_compile_args = []
+
+  [plugin]
+  name = "hydortrend"
+  requirements = [ "hydrotrend",]
+
+  [info]
+  plugin_author = "csdms"
+  github_username = "pymt-lab"
+  plugin_license = "MIT"
+  summary = "PyMT plugin for hydrotrend"
+
+
+You can use the *babelize quickstart* command to generate *babel.toml* files.
+For example the above *babel.toml* can be generated with the following,
 
 .. code:: bash
 
@@ -267,7 +268,7 @@ Generate Python bindings for a C library that implements a BMI,
 
 .. code:: bash
 
-  $ babelize init babel.yaml
+  $ babelize init babel.toml
 
 Update an existing repository
 

--- a/README.rst
+++ b/README.rst
@@ -265,10 +265,11 @@ Examples
 ********
 
 Generate Python bindings for a C library that implements a BMI,
+sending output to the current directory
 
 .. code:: bash
 
-  $ babelize init babel.toml
+  $ babelize init babel.toml .
 
 Update an existing repository
 

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -160,8 +160,23 @@ def update(template, quiet, verbose):
     "--entry-point", help="Entry point to the library BMI", multiple=True, default=None
 )
 @click.option("--requirement", help="Requirement", multiple=True, default=None)
+@click.option(
+    "--output",
+    default="-",
+    help="Write to file instead of stdout",
+    type=click.File("w"),
+)
 def quickstart(
-    batch, name, language, author, username, license, summary, entry_point, requirement
+    batch,
+    name,
+    language,
+    author,
+    username,
+    license,
+    summary,
+    entry_point,
+    requirement,
+    output,
 ):
     def ask_until_done(text):
         answers = []
@@ -200,7 +215,7 @@ def quickstart(
         entry_points = entry_point or ask_until_done("Entry point")
         requirements = requirement or ask_until_done("Requirement")
 
-    print(
+    output.write(
         BabelMetadata(
             library={"language": language, "entry_point": entry_points},
             plugin={"name": name, "requirements": requirements},

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -211,7 +211,7 @@ def quickstart(
                 "summary": summary,
             },
             build={},
-        ).format()
+        ).format(fmt="toml")
     )
 
 

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["cython", "numpy", "setuptools", "wheel"]
+
+[tool.pytest.ini_options]
+minversion = "5.0"
+testpaths = ["pymt_{{ cookiecutter.plugin_name }}", "tests"]
+norecursedirs = [".*", "*.egg*", "build", "dist"]
+addopts = """
+    --ignore setup.py
+    --ignore versioneer.py
+    --ignore babelizer/_version.py
+    --ignore pymt_{{ cookiecutter.plugin_name }}/_version.py
+    --tb native
+    --strict
+    --durations 16
+    --doctest-modules
+    -vvv
+"""
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "IGNORE_EXCEPTION_DETAIL",
+    "ALLOW_UNICODE"
+]
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+line_length = 88

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
@@ -1,3 +1,5 @@
+import numpy
+
 {%- for requirement in cookiecutter.plugin_requirements.split(',') %}
 # {{ requirement|trim }}
 {%- endfor %}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.cfg
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.cfg
@@ -6,30 +6,6 @@ versionfile_build = pymt_{{cookiecutter.plugin_name}}/_version.py
 tag_prefix = v
 parentdir_prefix = pymt_{{cookiecutter.plugin_name}}-
 
-[tool:pytest]
-minversion = 3.0
-testpaths = pymt_{{ cookiecutter.plugin_name }} tests
-norecursedirs = .* *.egg* build dist
-addopts =
-    --ignore setup.py
-    --ignore versioneer.py
-    --ignore pymt_{{ cookiecutter.plugin_name }}/_version.py
-    --tb native
-    --strict
-    --durations 16
-    --doctest-modules
-doctest_optionflags =
-    NORMALIZE_WHITESPACE
-    IGNORE_EXCEPTION_DETAIL
-    ALLOW_UNICODE
-
-[isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-line_length=88
-
 [flake8]
 exclude = docs
 ignore =

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click
 gitpython
 mock
 pyyaml
+toml
 isort>=5
 jinja2
 cookiecutter


### PR DESCRIPTION
This PR adds an `--output` option to the `babelize quickstart` command, and updates the README to show its use. Also fixed a few small issues in the README.