### PR TITLE
Fix folder where git init is called

### DIFF
--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -82,7 +82,7 @@ def render_plugin_repo(template, context=None, output_dir=".", clobber=False):
     if not path.is_dir():
         raise RenderError("error creating {0}".format(path))
 
-    git.Repo.init(output_dir)
+    git.Repo.init(path)
 
     return path
 


### PR DESCRIPTION
This pull request fixes a bug where `git init` was being called from the directory where `babelize init` was called rather than within the newly-created package.