### PR TITLE
Add generate subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ script:
 - babelize --help
 - babelize init --help
 - babelize update --help
-- babelize quickstart --help
-- babelize quickstart --batch
+- babelize generate --help
+- babelize generate - --no-input
 - python -c 'import babelizer; print(babelizer.__version__)'

--- a/README.rst
+++ b/README.rst
@@ -83,37 +83,40 @@ install *babelizer* into the current environment::
 Input file
 **********
 
-The *babelizer* requires a single, *yaml* formatted, input file that describes
-the library you would like to wrap. This file is typically called, *babel.yaml*.
-An example of a blank *babel.yaml* file,
+The *babelizer* requires a single, *toml* formatted, input file that describes
+the library you would like to wrap. This file is typically called, *babel.toml*.
+An example of a blank *babel.toml* file,
 
-.. code:: yaml
+.. code:: toml
 
-    build:
-      define_macros: []
-      extra_compile_args: []
-      include_dirs: []
-      libraries: []
-      library_dirs: []
-      undef_macros: []
-    info:
-      github_username: pymt-lab
-      plugin_author: csdms
-      plugin_license: MIT
-      summary: ''
-    library:
-      entry_point: []
-      language: c
-    plugin:
-      name: ''
-      requirements: []
+    [library]
+    language = "c"
+    entry_point = []
 
-You can generate *babel.yaml* files using the *babelize quickstart* command.
-For example, the above *babel.yaml* was generated with,
+    [build]
+    undef_macros = []
+    define_macros = []
+    libraries = []
+    library_dirs = []
+    include_dirs = []
+    extra_compile_args = []
+
+    [plugin]
+    name = ""
+    requirements = []
+
+    [info]
+    plugin_author = "csdms"
+    github_username = "pymt-lab"
+    plugin_license = "MIT"
+    summary = ""
+
+You can generate *babel.toml* files using the *babelize generate* command.
+For example, the above *babel.toml* was generated with,
 
 .. code:: bash
 
-  $ babelize quickstart --batch
+  $ babelize generate --no-input -
 
 
 Build section
@@ -163,20 +166,18 @@ A list of one or more entry points into the library.
 The following will define a Python class *Hydrotrend* that wraps the function
 *register_bmi_hydrotrend* defined in the library *bmi_hydrotrend*.
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    entry_point:
-    - Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend
+  [library]
+  entry_point = [ "Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend",]
 
 An example of a C++ library (*bmi_child*), exposing a class *Child* (which
 implemets a BMI) might look like the following,
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    entry_point:
-    - Child=bmi_child:Child
+  [library]
+  entry_point = [ "Child=bmi_child:Child",]
 
 Library language
 ----------------
@@ -184,10 +185,10 @@ Library language
 The programming language of the library (possible values are "c", "c++",
 "fortran", and "python").
 
-.. code:: yaml
+.. code:: toml
 
-  library:
-    language: c
+  [library]
+  language = "c"
 
 Plugin section
 ==============
@@ -201,10 +202,10 @@ Name to use for the wrapped package. This is used when create the new
 package, *pymt_<plugin_name>*. For example, the following will create
 a new package, *pymt_foo*.
 
-.. code:: yaml
+.. code:: toml
 
-  plugin:
-    name: foo
+  [plugin]
+  name = "foo"
 
 Requirements
 ------------
@@ -213,51 +214,50 @@ List of packages required by the libaray being wrapped. For example, the
 following indicates that the packages *foo* and *bar* are dependencies
 for the package.
 
-.. code:: yaml
+.. code:: toml
 
-  plugin:
-    requirements:
-    - foo
-    - bar
+  [plugin]
+  requirements = [ "foo", "bar",]
 
 
-Example babel.yaml
+Example babel.toml
 ==================
 
-Below is an example of a *babel.yaml* file that describes a shared library,
+Below is an example of a *babel.toml* file that describes a shared library,
 written in C. In this example, the library, *bmi_hydrotrend*, exposes the
 function *register_bmi_hydrotrend* that implements a BMI for a component
 called *hydrotrend*.
 
-.. code:: yaml
+.. code:: toml
 
-  build:
-    define_macros: []
-    extra_compile_args: []
-    include_dirs: []
-    libraries: []
-    library_dirs: []
-    undef_macros: []
-  info:
-    github_username: pymt-lab
-    plugin_author: csdms
-    plugin_license: MIT
-    summary: PyMT plugin for hydrotrend
-  library:
-    entry_point:
-    - Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend
-    language: c
-  plugin:
-    name: hydortrend
-    requirements:
-    - hydrotrend
+    [library]
+    language = "c"
+    entry_point = [ "Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend",]
 
-You can use the *babelize quickstart* command to generate *babel.yaml* files.
-For example the above *babel.yaml* can be generated with the following,
+    [build]
+    undef_macros = []
+    define_macros = []
+    libraries = []
+    library_dirs = []
+    include_dirs = []
+    extra_compile_args = []
+
+    [plugin]
+    name = "hydrotrend"
+    requirements = [ "hydrotrend",]
+
+    [info]
+    plugin_author = "csdms"
+    github_username = "pymt-lab"
+    plugin_license = "MIT"
+    summary = "PyMT plugin for hydrotrend"
+
+You can use the *babelize generate* command to generate *babel.toml* files.
+For example the above *babel.toml* can be generated with the following,
 
 .. code:: bash
 
-  $ babelize quickstart --batch --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydortrend --requirement=hydrotrend
+  $ babelize generate babel.toml --summary="PyMT plugin for hydrotrend" --entry-point=Hydrotrend=bmi_hydrotrend:register_bmi_hydrotrend --name=hydortrend --requirement=hydrotrend
 
 ********
 Examples
@@ -267,7 +267,7 @@ Generate Python bindings for a C library that implements a BMI,
 
 .. code:: bash
 
-  $ babelize init babel.yaml
+  $ babelize init babel.toml
 
 Update an existing repository
 

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -136,7 +136,7 @@ def update(template, quiet, verbose):
 
 @babelize.command()
 @click.option(
-    "--batch", is_flag=True, help="Run in batch mode using defaults for all values",
+    "--no-input", is_flag=True, help="Don’t ask questions, just use the default values",
 )
 @click.option(
     "--name", help="Name to use for the babelized package",
@@ -160,16 +160,18 @@ def update(template, quiet, verbose):
     "--entry-point", help="Entry point to the library BMI", multiple=True, default=None
 )
 @click.option("--requirement", help="Requirement", multiple=True, default=None)
-def quickstart(
-    batch, name, language, author, username, license, summary, entry_point, requirement
+@click.argument("file_", metavar="FILENAME", type=click.File(mode="w", lazy=True))
+def generate(
+    no_input, name, language, author, username, license, summary, entry_point, requirement, file_
 ):
+    """Generate babelizer config file, FILENAME."""
     def ask_until_done(text):
         answers = []
         while (answer := ask(text, default="done")) != "done":
             answers.append(answer)
         return answers
 
-    if batch:
+    if no_input:
         name = name or ""
         language = language or "c"
         author = author or "csdms"
@@ -211,7 +213,8 @@ def quickstart(
                 "summary": summary,
             },
             build={},
-        ).format()
+        ).format(fmt="toml"),
+        file=file_,
     )
 
 

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
@@ -1,3 +1,5 @@
+numpy
+
 {%- for requirement in cookiecutter.plugin_requirements.split(',') %}
 # {{ requirement|trim }}
 {%- endfor %}


### PR DESCRIPTION
This pull request renames `babelize quickstart` to `babelize generate` and adds an argument, `FILENAME`, that is either the name of the output file or `-` for *stdout*. This is pretty much the same as #12 but uses an argument rather than an option.