### PR TITLE
Remove versioneer from template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
 env:
   matrix:
   - PYTHON="3.8"
-  global:
-  - CONDA_PREFIX=$HOME/miniconda
-  - MINICONDA_URL_BASE="https://repo.anaconda.com/miniconda/Miniconda3-latest"
 sudo: false
 before_install:
 - |
@@ -18,18 +15,19 @@ before_install:
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    OS="MacOSX-x86_64"
+    curl -L https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
   else
-    OS="Linux-x86_64"
+    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
   fi
-- curl $MINICONDA_URL_BASE-$OS.sh > $HOME/minconda.sh
-- bash $HOME/minconda.sh -b -p $CONDA_PREFIX
-- export PATH="$CONDA_PREFIX/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda create -n _testing python=$PYTHON
-- source activate _testing
-- conda info -a && conda list
+- ./bin/micromamba shell init -s bash -p ~/micromamba
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    source $HOME/.bash_profile
+  else
+    source $HOME/.bashrc
+  fi
+- micromamba activate
+- micromamba install python=$PYTHON pip mamba --yes -c conda-forge
 install:
 - pip install .
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Changelog for babelizer
 - Fixed a bug where ``git init`` was called from the parent directory
   of the newly-created project, rather than from within the project.
 
+- Removed versioneer from the babelized package. The version is now
+  maintained within setup.py and releases should be made using
+  zest.releaser.
 
 0.1.3 (2018-10-28)
 ------------------

--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -1,0 +1,6 @@
+Credits
+=======
+
+* Eric Hutton
+
+* Mark Piper

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,3 @@ test_script:
   - cmd: babelize update --help
   - cmd: babelize generate --help
   - cmd: babelize generate - --no-input
-  - cmd: python -c \"import babelizer; print(babelizer.__version__)\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+environment:
+
+  global:
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\ci\\build.cmd"
+
+  matrix:
+
+    - PYTHON: "3.8"
+      MINICONDA: C:\\Miniconda38-x64
+
+    - PYTHON: "3.7"
+      MINICONDA: C:\\Miniconda37-x64
+
+    - PYTHON: "3.6"
+      MINICONDA: C:\\Miniconda36-x64
+
+platform:
+  - x64
+
+image: Visual Studio 2019
+
+init:
+  - "ECHO %PYTHON% %HOME% %PLATFORM%"
+  - "ECHO %APPVEYOR_REPO_BRANCH%"
+
+install:
+  - cmd: call %MINICONDA%\Scripts\activate.bat
+  - cmd: conda install mamba -c conda-forge --yes
+  - cmd: mamba config --set always_yes yes
+  - cmd: set PYTHONUNBUFFERED=1
+  - cmd: mamba list
+  - cmd: python --version
+
+build: false
+
+test_script:
+  - cmd: pip install -e .
+  - cmd: babelize --version
+  - cmd: babelize --help
+  - cmd: babelize init --help
+  - cmd: babelize update --help
+  - cmd: babelize generate --help
+  - cmd: babelize generate - --no-input
+  - cmd: python -c 'import babelizer; print(babelizer.__version__)'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,6 @@ environment:
     - PYTHON: "3.8"
       MINICONDA: C:\\Miniconda38-x64
 
-    - PYTHON: "3.7"
-      MINICONDA: C:\\Miniconda37-x64
-
-    - PYTHON: "3.6"
-      MINICONDA: C:\\Miniconda36-x64
-
 platform:
   - x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ test_script:
   - cmd: babelize update --help
   - cmd: babelize generate --help
   - cmd: babelize generate - --no-input
-  - cmd: python -c 'import babelizer; print(babelizer.__version__)'
+  - cmd: python -c \"import babelizer; print(babelizer.__version__)\"

--- a/babelizer/data/cookiecutter.json
+++ b/babelizer/data/cookiecutter.json
@@ -3,6 +3,7 @@
   "plugin_requirements": "",
   "plugin_module": "plugin",
   "plugin_class": "{{ cookiecutter.plugin_name|title }}",
+  "plugin_version": "0.1",
   "language": ["c", "c++", "fortran", "python"],
   "pymt_class": "{{ cookiecutter.plugin_class }}",
   "undef_macros": "",
@@ -11,9 +12,10 @@
   "library_dirs": "",
   "include_dirs": "",
   "extra_compile_args": "",
-  "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
+  "open_source_license": ["MIT License", "BSD License", "ISC License", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
   "project_short_description": "PyMT plugin for {{cookiecutter.plugin_name}}",
   "full_name": "Eric Hutton",
+  "email": "csdms@colorado.edu",
   "github_username": "mcflugen",
   "entry_points": "Foo=bar:Baz"
 }

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/.travis.yml
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/.travis.yml
@@ -38,8 +38,8 @@ before_install:
 - source activate _testing
 - conda info -a && conda list
 install:
-- pip install .
 - conda install -q --file=requirements-library.txt
+- pip install .
 script:
 - conda install -q --file=requirements-testing.txt
 - python -c 'import pymt_{{ cookiecutter.plugin_name }}'

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/.travis.yml
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/.travis.yml
@@ -38,8 +38,8 @@ before_install:
 - source activate _testing
 - conda info -a && conda list
 install:
-- conda install -q --file=requirements.txt
 - pip install .
+- conda install -q --file=requirements-library.txt
 script:
 - conda install -q --file=requirements-testing.txt
 - python -c 'import pymt_{{ cookiecutter.plugin_name }}'

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/CHANGES.rst
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/CHANGES.rst
@@ -1,0 +1,12 @@
+Changelog for pymt_{{cookiecutter.plugin_name}}
+==================={{ '=' * cookiecutter.plugin_name | length }}
+
+0.2.0 (unreleased)
+-------------------
+
+
+0.1.0 ({% now 'local', '%Y-%m-%d' %})
+------------------
+
+- Initial release
+

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/CREDITS.rst
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/CREDITS.rst
@@ -1,0 +1,4 @@
+Credits
+=======
+
+* {{ cookiecutter.full_name }} <{{ cookiecutter.email }}>

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/LICENSE
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/LICENSE
@@ -1,4 +1,4 @@
-{% if cookiecutter.open_source_license == 'MIT license' -%}
+{% if cookiecutter.open_source_license == 'MIT License' -%}
 MIT License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -20,7 +20,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD license' %}
+{% elif cookiecutter.open_source_license == 'BSD License' %}
 
 BSD License
 
@@ -51,7 +51,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.open_source_license == 'ISC license' -%}
+{% elif cookiecutter.open_source_license == 'ISC License' -%}
 ISC License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/MANIFEST.in
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/MANIFEST.in
@@ -1,3 +1,13 @@
-recursive-include pymt_{{ cookiecutter.plugin_name }}/data/ *
+recursive-include pymt_{{ cookiecutter.plugin_name }}/data *
 include LICENSE
 include requirements.txt
+include *.rst
+include *.txt
+include Makefile
+include babel.toml
+include pymt_rafem/data
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+recursive-exclude meta *
+recursive-exclude recipe *

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/README.rst
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/README.rst
@@ -70,7 +70,7 @@ into which to install it. This can be done with,
 
 .. code::
 
-  conda create -n pymt python=3.6
+  conda create -n pymt python=3
   conda activate pymt
 
 Once the `conda-forge` channel has been enabled, `pymt` can be installed with:

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/__init__.py
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/__init__.py
@@ -1,4 +1,9 @@
 #! /usr/bin/env python
+import pkg_resources
+
+
+__version__ = pkg_resources.get_distribution("pymt_{{ cookiecutter.plugin_name }}").version
+
 
 from .bmi import (
 {%- for entry_point in cookiecutter.entry_points.split(',') %}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
@@ -11,8 +11,9 @@ from __future__ import absolute_import
 from .lib import {{ classes|join(', ') }}
 
 {%- else %}
+import pkg_resources
 
-    {% for entry_point in cookiecutter.entry_points.split(',') %}
+{% for entry_point in cookiecutter.entry_points.split(',') %}
         {%- set pymt_class = entry_point.split('=')[0] -%}
         {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') -%}
 
@@ -22,6 +23,7 @@ from {{ plugin_module }} import {{ plugin_class }} as {{ pymt_class }}
 
     {%- for cls in classes %}
 {{ cls }}.__name__ = "{{ cls }}"
+{{ cls }}.METADATA = pkg_resources.resource_filename(__name__ , "data/{{ cls }}")
     {%- endfor %}
 
 {%- endif %}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/pyproject.toml
@@ -7,9 +7,6 @@ testpaths = ["pymt_{{ cookiecutter.plugin_name }}", "tests"]
 norecursedirs = [".*", "*.egg*", "build", "dist"]
 addopts = """
     --ignore setup.py
-    --ignore versioneer.py
-    --ignore babelizer/_version.py
-    --ignore pymt_{{ cookiecutter.plugin_name }}/_version.py
     --tb native
     --strict
     --durations 16
@@ -28,3 +25,9 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
+
+[tool.check-manifest]
+ignore = [
+  "pymt_{{ cookiecutter.plugin_name }}/data",
+  "pymt_{{ cookiecutter.plugin_name }}/data/**/*",
+]

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements-library.txt
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements-library.txt
@@ -1,0 +1,3 @@
+{%- for requirement in cookiecutter.plugin_requirements.split(',') %}
+{{ requirement|trim }}
+{%- endfor %}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/requirements.txt
@@ -1,5 +1,1 @@
 numpy
-
-{%- for requirement in cookiecutter.plugin_requirements.split(',') %}
-# {{ requirement|trim }}
-{%- endfor %}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.cfg
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.cfg
@@ -1,11 +1,3 @@
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = pymt_{{cookiecutter.plugin_name}}/_version.py
-versionfile_build = pymt_{{cookiecutter.plugin_name}}/_version.py
-tag_prefix = v
-parentdir_prefix = pymt_{{cookiecutter.plugin_name}}-
-
 [flake8]
 exclude = docs
 ignore =
@@ -13,3 +5,6 @@ ignore =
 	E501
 	W503
 max-line-length = 88
+
+[zest.releaser]
+tag-format = v{version}

--- a/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/babelizer/data/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -8,7 +8,6 @@ import subprocess
 {%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}
 import numpy as np
 {% endif %}
-import versioneer
 from setuptools import Extension, find_packages, setup
 
 {% if cookiecutter.language == 'fortran' -%}
@@ -98,8 +97,6 @@ entry_points = {
     ]
 }
 
-cmdclass=versioneer.get_cmdclass()
-
 {% if cookiecutter.language == 'fortran' %}
 def build_interoperability():
     compiler = new_fcompiler()
@@ -134,18 +131,40 @@ cmdclass["build_ext"] = build_ext
 {% endif -%}
 
 
+def read(filename):
+    with open(filename, "r", encoding="utf-8") as fp:
+        return fp.read()
+
+
+long_description = u'\n\n'.join(
+    [read('README.rst'), read('CREDITS.rst'), read('CHANGES.rst')]
+)
+
+
 setup(
     name="pymt_{{cookiecutter.plugin_name}}",
     author="{{cookiecutter.full_name}}",
+    author_email="{{cookiecutter.email}}",
     description="PyMT plugin for {{cookiecutter.plugin_name}}",
-    version=versioneer.get_version(),
+    long_description=long_description,
+    version="{{cookiecutter.plugin_version}}",
+    url="https://github.com/{{ cookiecutter.github_username }}/pymt_{{ cookiecutter.plugin_name }}",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: {{ cookiecutter.open_source_license }}",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+    ],
+    keywords=["bmi", "pymt"],
     install_requires=open("requirements.txt", "r").read().splitlines(),
 {%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}
     setup_requires=["cython"],
     ext_modules=ext_modules,
 {%- endif %}
     packages=find_packages(),
-    cmdclass=cmdclass,
     entry_points=entry_points,
     include_package_data=True,
 )

--- a/babelizer/errors.py
+++ b/babelizer/errors.py
@@ -24,3 +24,8 @@ class ScanError(BabelizeError):
 class OutputDirExistsError(BabelizeError):
 
     pass
+
+
+class SetupPyError(BabelizeError):
+
+    pass

--- a/babelizer/metadata.py
+++ b/babelizer/metadata.py
@@ -124,7 +124,7 @@ class BabelMetadata:
             raise ValueError(f"unrecognized format ({fmt})")
 
         try:
-            return cls(**loader(stream))
+            return cls(**loader(stream.read()))
         except TypeError:
             raise ValidationError("metadata file does not contain a mapping object")
         except yaml.scanner.ScannerError as error:
@@ -169,6 +169,7 @@ class BabelMetadata:
             },
             "info": {
                 "plugin_author": config["info"]["plugin_author"],
+                "plugin_author_email": config["info"]["plugin_author_email"],
                 "github_username": config["info"]["github_username"],
                 "plugin_license": config["info"]["plugin_license"],
                 "summary": config["info"]["summary"],
@@ -213,6 +214,7 @@ class BabelMetadata:
         return {
             "entry_points": entry_points,
             "full_name": self._meta["info"]["plugin_author"],
+            "email": self._meta["info"]["plugin_author_email"],
             "github_username": self._meta["info"]["github_username"],
             "plugin_name": self._meta["plugin"]["name"],
             "plugin_module": plugin_module,

--- a/babelizer/metadata.py
+++ b/babelizer/metadata.py
@@ -96,6 +96,27 @@ def validate_meta(meta):
             )
 
 
+def validate_dict(meta, required=None, optional=None):
+    actual = set(meta)
+    required = set() if required is None else set(required)
+    optional = required if optional is None else set(optional)
+    valid = required | optional
+
+    if missing := required - actual:
+        raise ValidationError(
+            "missing required key{0}: {1}".format(
+                "s" if len(missing) > 1 else "", ", ".join(missing)
+            )
+        )
+
+    if unknown := actual - valid:
+        raise ValidationError(
+            "unknown key{0}: {1}".format(
+                "s" if len(unknown) > 1 else "", ", ".join(unknown)
+            )
+        )
+
+
 class BabelMetadata:
     REQUIRED = {
         "library": ("language", "entry_point"),
@@ -106,15 +127,16 @@ class BabelMetadata:
     LOADERS = {"yaml": yaml.safe_load, "toml": toml.parse}
 
     def __init__(self, library=None, build=None, plugin=None, info=None):
-        self._meta = BabelMetadata.norm(
-            {
-                "library": library or {},
-                "build": build or {},
-                "plugin": plugin or {},
-                "info": info or {},
-            }
-        )
-        validate_meta(self._meta)
+        config = {
+            "library": library or {},
+            "build": build or {},
+            "plugin": plugin or {},
+            "info": info or {}
+        }
+
+        BabelMetadata.validate(config)
+
+        self._meta = BabelMetadata.norm(config)
 
     @classmethod
     def from_stream(cls, stream, fmt="yaml"):
@@ -128,13 +150,9 @@ class BabelMetadata:
         except TypeError:
             raise ValidationError("metadata file does not contain a mapping object")
         except yaml.scanner.ScannerError as error:
-            raise ScanError(
-                f"unable to scan yaml-formatted metadata file:\n{error}"
-            )
+            raise ScanError(f"unable to scan yaml-formatted metadata file:\n{error}")
         except toml.exceptions.ParseError as error:
-            raise ScanError(
-                f"unable to scan toml-formatted metadata file:\n{error}"
-            )
+            raise ScanError(f"unable to scan toml-formatted metadata file:\n{error}")
 
     @classmethod
     def from_path(cls, filepath):
@@ -147,13 +165,54 @@ class BabelMetadata:
         return self._meta[section][value]
 
     @staticmethod
+    def validate(config):
+        validate_dict(config["library"], required=("language", "entry_point"), optional={})
+        validate_dict(
+            config["build"],
+            required=None,
+            optional=(
+                "undef_macros",
+                "define_macros",
+                "libraries",
+                "library_dirs",
+                "include_dirs",
+                "extra_compile_args",
+            ),
+        )
+        validate_dict(config["plugin"], required=("name", "requirements"), optional={})
+        validate_dict(
+            config["info"],
+            required=(
+                "plugin_author",
+                "plugin_author_email",
+                "github_username",
+                "plugin_license",
+                "summary",
+            ),
+            optional={},
+        )
+
+        if isinstance(entry_points := config["library"]["entry_point"], str):
+            entry_points = [entry_points]
+
+        for entry_point in entry_points:
+            try:
+                BabelMetadata.parse_entry_point(entry_point)
+            except ValidationError:
+                raise ValidationError(f"poorly-formed entry point ({entry_point})")
+
+    @staticmethod
     def norm(config):
         if "build" not in config:
             config["build"] = {}
+
+        if isinstance(entry_points := config["library"]["entry_point"], str):
+            entry_points = [entry_points]
+
         return {
             "library": {
                 "language": config["library"]["language"],
-                "entry_point": list(config["library"]["entry_point"]),
+                "entry_point": list(entry_points),
             },
             "build": {
                 "undef_macros": config["build"].get("undef_macros", []),
@@ -178,7 +237,6 @@ class BabelMetadata:
 
     def dump(self, fp, fmt="yaml"):
         print(self.format(fmt=fmt), file=fp)
-        # yaml.safe_dump(self._meta, fp, default_flow_style=False)
 
     def format(self, fmt="yaml"):
         return getattr(self, f"format_{fmt}")()
@@ -195,10 +253,43 @@ class BabelMetadata:
 
     @staticmethod
     def parse_entry_point(specifier):
-        name, value = specifier.split("=")
-        module, obj = value.split(":")
+        """Parse an entry point specifier into its parts.
 
-        return name.strip(), module.strip(), obj.strip()
+        Parameters
+        ----------
+        specifier : str
+            An entry-point specifier.
+
+        Returns
+        -------
+        tupe of str
+            The parts of the entry point as (*name*, *module*, *class*).
+
+        Raises
+        ------
+        ValidationError
+            If the entry point cannot be parsed.
+
+        Examples
+        --------
+        >>> from babelizer.metadata import BabelMetadata
+        >>> BabelMetadata.parse_entry_point("Foo=bar:Baz")
+        ('Foo', 'bar', 'Baz')
+
+        >>> BabelMetadata.parse_entry_point("bar:Baz")
+        Traceback (most recent call last):
+        ,,,
+        babelizer.errors.ValidationError: bad entry point specifier (bar:Baz). specifier must be of the form name=module:class
+        """
+        try:
+            name, value = [item.strip() for item in specifier.split("=")]
+            module, obj = [item.strip() for item in value.split(":")]
+        except ValueError:
+            raise ValidationError(
+                f"bad entry point specifier ({specifier}). specifier must be of the form name=module:class"
+            ) from None
+
+        return name, module, obj
 
     def as_cookiecutter_context(self):
         language = self._meta["library"]["language"]
@@ -206,8 +297,7 @@ class BabelMetadata:
         plugin_class = ""
         entry_point = ""
 
-        entry_points = self._meta["library"]["entry_point"]
-        if isinstance(entry_points, str):
+        if isinstance(entry_points := self._meta["library"]["entry_point"], str):
             entry_points = [entry_points]
         entry_points = ",".join(entry_points)
 

--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -1,29 +1,28 @@
 import contextlib
 import os
 import pathlib
-import subprocess
-import sys
 
 import black as blk
 import git
 import isort
 import pkg_resources
 import toml
-import yaml
 from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
 
 from .errors import OutputDirExistsError, RenderError
 
 
-def render(plugin_metadata, output, template=None, clobber=False):
+def render(plugin_metadata, output, template=None, clobber=False, version="0.1"):
     if template is None:
         template = pkg_resources.resource_filename("babelizer", "data")
 
     try:
         path = render_plugin_repo(
             template,
-            context=plugin_metadata.as_cookiecutter_context(),
+            context=dict(
+                plugin_metadata.as_cookiecutter_context(), plugin_version=version
+            ),
             output_dir=output,
             clobber=clobber,
         )

--- a/babelizer/utils.py
+++ b/babelizer/utils.py
@@ -1,0 +1,44 @@
+import pathlib
+import subprocess
+import sys
+from contextlib import contextmanager
+
+from .errors import SetupPyError
+
+
+def execute(args):
+    return subprocess.run(args, capture_output=True, check=True)
+
+
+def setup_py(*args):
+    return [sys.executable, "setup.py"] + list(args)
+
+
+def get_setup_py_version():
+    if pathlib.Path("setup.py").exists():
+        try:
+            execute(setup_py("egg_info"))
+        except subprocess.CalledProcessError as err:
+            stderr = err.stderr.decode("utf-8")
+            if "Traceback" in stderr:
+                raise SetupPyError(stderr) from None
+            return None
+        result = execute(setup_py("--version"))
+        return result.stdout.splitlines()[0].decode("utf-8")
+    else:
+        return None
+
+
+@contextmanager
+def save_files(files):
+    contents = {}
+    for file_ in files:
+        try:
+            with open(file_, "r") as fp:
+                contents[file_] = fp.read()
+        except FileNotFoundError:
+            pass
+    yield contents
+    for file_ in contents:
+        with open(file_, "w") as fp:
+            fp.write(contents[file_])

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,21 @@
 from setuptools import find_packages, setup
 
 
+def read(filename):
+    with open(filename, "r", encoding="utf-8") as fp:
+        return fp.read()
+
+
+long_description = u'\n\n'.join(
+    [read('README.rst'), read('CREDITS.rst'), read('CHANGES.rst')]
+)
+
+
 setup(
     name="babelizer",
     version="0.1.3",
     description="Wrap bmi libraries with Python bindings",
-    long_description=open("README.rst", encoding="utf-8").read(),
+    long_description=long_description,
     author="Eric Hutton",
     author_email="huttone@colorado.edu",
     url="https://github.com/csdms",


### PR DESCRIPTION
This pull request removes *versioneer* from the language templates and, instead, versions will be maintained with *zest.releaser*. With this change, the version of the babelized package is specified in *setup.py*. The version can be set when the package is first created with *babelize init* through the `--package-version` option. For existing packages, users change the version directly in *setup.py* (*babelize update* reads the version from *setup.py*).

Other changes include things that make the generated repository more compliant with standard packaging practices.