### PR TITLE
Get package version for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,8 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import datetime
+import pkg_resources
 
 
 # The master toctree document.
@@ -21,11 +23,11 @@ master_doc = 'index'
 # -- Project information -----------------------------------------------------
 
 project = 'babelizer'
-copyright = '2020, Community Surface Dynamics Modeling System'
 author = 'Community Surface Dynamics Modeling System'
-
-# The full version, including alpha/beta/rc tags
-release = '0.2'
+version = pkg_resources.get_distribution("babelizer").version
+release = version
+this_year = datetime.date.today().year
+copyright = '%s, %s' % (this_year, author)
 
 
 # -- General configuration ---------------------------------------------------

--- a/tests/test_c/babel.toml
+++ b/tests/test_c/babel.toml
@@ -11,7 +11,7 @@ github_username = "mcflugen"
 plugin_author = "Eric Hutton"
 plugin_author_email = "eric.hutton@colorado.edu"
 plugin_license = "MIT"
-summary = "PyMT plugin for hydrotrend"
+summary = "PyMT plugin for heat model"
 
 [library]
 entry_point = ["HeatBMI=bmiheatc:register_bmi_heat"]
@@ -20,4 +20,3 @@ language = "c"
 [plugin]
 name = "heat"
 requirements = []
-


### PR DESCRIPTION
This PR uses the [technique](https://zestreleaser.readthedocs.io/en/latest/versions.html#using-the-version-number-in-setup-py-or-setup-cfg-as-version) recommended in the *zest.releaser* docs for getting the package version for Sphinx docs, ensuring that there's only one location where the version is set.

Also fixed a trivial typo in the test data.