### PR TITLE
Add missing unstructured grid methods to C/C++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
     source $HOME/.bashrc
   fi
 - micromamba activate
-- micromamba install mamba --yes -c conda-forge
+- micromamba install mamba --yes -c conda-forge -p $MAMBA_ROOT_PREFIX
 - mamba create -n testing python=$PYTHON --file=requirements-testing.txt --yes -c conda-forge
 - source activate testing
 - |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@ Changelog for babelizer
 0.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added missing methods, primarily for unstructured grids, to C and C++
+  implementation
+
+- Fixed a rendering error that caused import lines to run together
+  when wrapping multiple components
+
+- Removed Python 3.6 builds
 
 
 0.3.2 (2020-10-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,12 @@ Changelog for babelizer
 ------------------
 
 - Added missing methods, primarily for unstructured grids, to C and C++
-  implementation
+  implementation (#28)
 
 - Fixed a rendering error that caused import lines to run together
-  when wrapping multiple components
+  when wrapping multiple components (#28)
 
-- Removed Python 3.6 builds
+- Removed Python 3.6 builds (#28)
 
 
 0.3.2 (2020-10-08)

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/travis/csdms/babelizer.svg
-        :target: https://travis-ci.org/csdms/babelizer
+.. image:: https://travis-ci.com/csdms/babelizer.svg?branch=master
+        :target: https://travis-ci.com/csdms/babelizer
 
 .. image:: https://readthedocs.org/projects/babelizer/badge/?version=latest
         :target: https://babelizer.readthedocs.io/en/latest/?badge=latest

--- a/babelizer/data/{{cookiecutter.package_name}}/.travis.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.travis.yml
@@ -4,7 +4,6 @@ os:
 - linux
 env:
   matrix:
-  - PYTHON="3.6"
   - PYTHON="3.7"
   - PYTHON="3.8"
   global:
@@ -38,6 +37,7 @@ before_install:
 - source activate _testing
 - conda info -a && conda list
 install:
+- conda install -q --file=requirements-build.txt
 - conda install -q --file=requirements-library.txt
 - pip install -e .
 script:

--- a/babelizer/data/{{cookiecutter.package_name}}/MANIFEST.in
+++ b/babelizer/data/{{cookiecutter.package_name}}/MANIFEST.in
@@ -5,8 +5,11 @@ include *.rst
 include *.txt
 include Makefile
 include babel.toml
+recursive-include {{ cookiecutter.package_name }} *.pyx
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile
 recursive-exclude meta *
 recursive-exclude recipe *
+recursive-exclude {{ cookiecutter.package_name }} *.cpp
+recursive-exclude {{ cookiecutter.package_name }} *.c

--- a/babelizer/data/{{cookiecutter.package_name}}/requirements-testing.txt
+++ b/babelizer/data/{{cookiecutter.package_name}}/requirements-testing.txt
@@ -1,1 +1,1 @@
-bmi-tester
+bmi-tester>=0.5.4

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/__init__.py
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/__init__.py
@@ -2,7 +2,7 @@
 
 {% for babelized_class in cookiecutter.components -%}
 from .{{ babelized_class|lower }} import {{ babelized_class }}
-{%- endfor %}
+{% endfor %}
 
 __all__ = [
 {%- for babelized_class in cookiecutter.components -%}

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_c.pyx
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_c.pyx
@@ -309,15 +309,15 @@ cdef class {{ babelized_class }}:
 
     cpdef get_grid_x(self, gid, np.ndarray[double, ndim=1] buff):
         ok_or_raise(<int>self._bmi.get_grid_x(self._bmi, gid, &buff[0]))
-        return origin
+        return buff
 
     cpdef get_grid_y(self, gid, np.ndarray[double, ndim=1] buff):
         ok_or_raise(<int>self._bmi.get_grid_y(self._bmi, gid, &buff[0]))
-        return origin
+        return buff
 
     cpdef get_grid_z(self, gid, np.ndarray[double, ndim=1] buff):
         ok_or_raise(<int>self._bmi.get_grid_z(self._bmi, gid, &buff[0]))
-        return origin
+        return buff
 
     cpdef get_grid_edge_nodes(self, gid, np.ndarray[int, ndim=1] buff):
         ok_or_raise(<int>self._bmi.get_grid_edge_nodes(self._bmi, gid, &buff[0]))

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_c.pyx
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_c.pyx
@@ -278,7 +278,17 @@ cdef class {{ babelized_class }}:
 
     cpdef int get_grid_node_count(self, gid):
         cdef int size
-        ok_or_raise(<int>self._bmi.get_grid_size(self._bmi, gid, &size))
+        ok_or_raise(<int>self._bmi.get_grid_node_count(self._bmi, gid, &size))
+        return size
+
+    cpdef int get_grid_edge_count(self, gid):
+        cdef int size
+        ok_or_raise(<int>self._bmi.get_grid_edge_count(self._bmi, gid, &size))
+        return size
+
+    cpdef int get_grid_face_count(self, gid):
+        cdef int size
+        ok_or_raise(<int>self._bmi.get_grid_face_count(self._bmi, gid, &size))
         return size
 
     cpdef object get_grid_type(self, gid):
@@ -297,4 +307,31 @@ cdef class {{ babelized_class }}:
         ok_or_raise(<int>self._bmi.get_grid_origin(self._bmi, gid, &origin[0]))
         return origin
 
+    cpdef get_grid_x(self, gid, np.ndarray[double, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_x(self._bmi, gid, &buff[0]))
+        return origin
+
+    cpdef get_grid_y(self, gid, np.ndarray[double, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_y(self._bmi, gid, &buff[0]))
+        return origin
+
+    cpdef get_grid_z(self, gid, np.ndarray[double, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_z(self._bmi, gid, &buff[0]))
+        return origin
+
+    cpdef get_grid_edge_nodes(self, gid, np.ndarray[int, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_edge_nodes(self._bmi, gid, &buff[0]))
+        return buff
+
+    cpdef get_grid_face_edges(self, gid, np.ndarray[int, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_face_edges(self._bmi, gid, &buff[0]))
+        return buff
+
+    cpdef get_grid_face_nodes(self, gid, np.ndarray[int, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_face_nodes(self._bmi, gid, &buff[0]))
+        return buff
+
+    cpdef get_grid_nodes_per_face(self, gid, np.ndarray[int, ndim=1] buff):
+        ok_or_raise(<int>self._bmi.get_grid_nodes_per_face(self._bmi, gid, &buff[0]))
+        return buff
 {% endfor %}

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_cxx.pyx
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/lib/_cxx.pyx
@@ -189,11 +189,19 @@ cdef class {{ babelized_class }}:
         self._bmi.GetGridY(gid, &buff[0])
         return buff
 
+    cpdef get_grid_z(self, gid, np.ndarray[double, ndim=1] buff):
+        self._bmi.GetGridZ(gid, &buff[0])
+        return buff
+
     cpdef get_grid_face_nodes(self, gid, np.ndarray[int, ndim=1] buff):
         self._bmi.GetGridFaceNodes(gid, &buff[0])
         return buff
 
     cpdef get_grid_nodes_per_face(self, gid, np.ndarray[int, ndim=1] buff):
         self._bmi.GetGridNodesPerFace(gid, &buff[0])
+        return buff
+
+    cpdef get_grid_edge_nodes(self, gid, np.ndarray[int, ndim=1] buff):
+        self._bmi.GetGridEdgeNodes(gid, &buff[0])
         return buff
 {% endfor %}

--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -21,7 +21,7 @@ def render(plugin_metadata, output, template=None, clobber=False, version="0.1")
         path = render_plugin_repo(
             template,
             context=dict(
-                plugin_metadata.as_cookiecutter_context(), plugin_version=version
+                plugin_metadata.as_cookiecutter_context(), package_version=version
             ),
             output_dir=output,
             clobber=clobber,

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-bmi-tester
+bmi-tester>=0.5.4
 bmi-c
 bmi-cxx
 bmi-fortran


### PR DESCRIPTION
This pull request fixes some outstanding issues with the *babelizer*.
* added missing unstructured grid methods to C/C++ implementations
* Fixed an issue where import lines ran together when wrapping multiple components
* drop Python 3.6 builds
* Fixed an issue in the CI where the build requirements were not getting installed