### PR TITLE
Build Python BMIs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/bmi-example-cxx"]
 	path = external/bmi-example-cxx
 	url = https://github.com/csdms/bmi-example-cxx
+[submodule "external/bmi-example-python"]
+	path = external/bmi-example-python
+	url = https://github.com/csdms/bmi-example-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ before_install:
   &&   cmake ../external/bmi-example-cxx -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
   &&   make install \
   &&   popd
+- |
+  pushd ./external/bmi-example-python \
+  && make install \
+  && popd
 install:
 - pip install .
 script:

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Supported languages:
 *  C
 *  C++
 *  Fortran
+*  Python
 
 The *babelizer* is an element of the `CSDMS Workbench`_,
 an integrated system of software tools, technologies, and standards

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
@@ -12,9 +12,9 @@ from .lib import {{ classes|join(', ') }}
 {%- else %}
 import pkg_resources
 
-{% for babelized_class, component in cookiecutter.components %}
+{% for babelized_class, component in cookiecutter.components|dictsort %}
 
-from {{ component.library }} import {{ component.class }} as {{ babelized_class }}
+from {{ component.library }} import {{ component.entry_point }} as {{ babelized_class }}
 
     {%- endfor %}
 

--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
@@ -20,7 +20,7 @@ from {{ component.library }} import {{ component.entry_point }} as {{ babelized_
 
     {%- for cls in classes %}
 {{ cls }}.__name__ = "{{ cls }}"
-{{ cls }}.METADATA = pkg_resources.resource_filename(__name__ , "data/{{ cls }}")
+{{ cls }}.METADATA = pkg_resources.resource_filename(__name__ , "meta/{{ cls }}")
     {%- endfor %}
 
 {%- endif %}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ Supported languages include:
 * C
 * C++
 * Fortran
+* Python
 
 Within Python, these models, regardless of their core language,
 appear as classes that expose a BMI.

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,6 +2,7 @@ bmi-tester>=0.5.4
 bmi-c
 bmi-cxx
 bmi-fortran
+bmipy
 cmake
 c-compiler
 cxx-compiler

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import os
+import pathlib
+import shutil
+import subprocess
+
+from click.testing import CliRunner
+
+from babelizer.cli import babelize
+
+
+def test_babelize_init_python(tmpdir, datadir):
+    runner = CliRunner()
+
+    with tmpdir.as_cwd():
+        shutil.copy(datadir / "babel.toml", ".")
+        result = runner.invoke(babelize, ["init", "babel.toml", "."])
+
+        assert result.exit_code == 0
+        assert pathlib.Path("pymt_heatpy").exists()
+        assert (pathlib.Path("pymt_heatpy") / "babel.toml").is_file()
+
+        try:
+            result = subprocess.run(
+                ["pip", "install", "-e", "."],
+                cwd="pymt_heatpy",
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as err:
+            assert err.output is None, err.output
+
+        assert result.returncode == 0
+
+        os.mkdir("_test")
+        shutil.copy(datadir / "heat.yaml", "_test/")
+
+        try:
+            result = subprocess.run(
+                [
+                    "bmi-test",
+                    "--config-file=heat.yaml",
+                    "--root-dir=.",
+                    "pymt_heatpy:HeatPy",
+                    "-vvv",
+                ],
+                cwd="_test",
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as err:
+            assert err.output is None, err.output
+
+        assert result.returncode == 0

--- a/tests/test_python/babel.toml
+++ b/tests/test_python/babel.toml
@@ -1,0 +1,25 @@
+[library]
+[library.HeatPy]
+language = "python"
+library = "heat"
+header = ""
+entry_point = "BmiHeat"
+
+[build]
+undef_macros = []
+define_macros = []
+libraries = []
+library_dirs = []
+include_dirs = []
+extra_compile_args = []
+
+[package]
+name = "pymt_heatpy"
+requirements = []
+
+[info]
+github_username = "csdms"
+package_author = "CSDMS"
+package_author_email = "csdms@colorado.edu"
+package_license = "MIT"
+summary = "PyMT component for the heatpy model"

--- a/tests/test_python/heat.yaml
+++ b/tests/test_python/heat.yaml
@@ -1,0 +1,11 @@
+# Heat model configuration
+shape:
+  - 6
+  - 8
+spacing:
+  - 1.0
+  - 1.0
+origin:
+  - 0.0
+  - 0.0
+alpha: 1.0


### PR DESCRIPTION
This PR fixes a minor templating issue in the *babelizer* that prevented it from building Python BMIs. To ensure it's working, the [bmi-example-python](https://github.com/csdms/bmi-example-python) repo has been added to the set of language tests, alongside those for C, C++, and Fortran. 