### PR TITLE
Revert "Change name of metadata directory"

### DIFF
--- a/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
+++ b/babelizer/data/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/bmi.py
@@ -20,7 +20,7 @@ from {{ component.library }} import {{ component.entry_point }} as {{ babelized_
 
     {%- for cls in classes %}
 {{ cls }}.__name__ = "{{ cls }}"
-{{ cls }}.METADATA = pkg_resources.resource_filename(__name__ , "meta/{{ cls }}")
+{{ cls }}.METADATA = pkg_resources.resource_filename(__name__ , "data/{{ cls }}")
     {%- endfor %}
 
 {%- endif %}

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -33,6 +33,8 @@ def test_babelize_init_python(tmpdir, datadir):
             assert err.output is None, err.output
 
         assert result.returncode == 0
+        assert pathlib.Path("pymt_heatpy/pymt_heatpy/data/HeatPy").exists()
+        assert pathlib.Path("pymt_heatpy/pymt_heatpy/data/HeatPy/api.yaml").is_file()
 
         os.mkdir("_test")
         shutil.copy(datadir / "heat.yaml", "_test/")


### PR DESCRIPTION
This reverts commit 88220cf40562bbc9a8b9b7f686e3c6697f8cc184, which fixes #35.

This statement gives the location of the installed model metadata. Changing it here in the babelizer causes problems downstream--it confuses the model_metadata package, which raises an exception from within pymt. I didn't fully understand the consequences of this change when I made it.
