### PR TITLE
Tweak workflows

### DIFF
--- a/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          black_args: "{{ cookiecutter.package_name }} --check"
+          args: "{{ cookiecutter.package_name }} --check"

--- a/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          args: "{{ cookiecutter.package_name }} --check"
+          args: ". --check"

--- a/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/black.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
-  lint:
+  format:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          black_args: ". --check"
+          black_args: "{{ cookiecutter.package_name }} --check"

--- a/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/flake8.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/flake8.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Lint
         run: |
           pip install flake8
-          flake8
+          flake8 {{ cookiecutter.package_name }}

--- a/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/test.yml
+++ b/babelizer/data/{{cookiecutter.package_name}}/.github/workflows/test.yml
@@ -40,8 +40,7 @@ jobs:
       - name: Install requirements
         run: |
           conda install mamba
-          mamba install --file=requirements-build.txt
-          mamba install --file=requirements-library.txt
+          mamba install --file=requirements-build.txt --file=requirements-library.txt
           mamba list
 
       - name: Build and install package

--- a/babelizer/data/{{cookiecutter.package_name}}/README.rst
+++ b/babelizer/data/{{cookiecutter.package_name}}/README.rst
@@ -12,16 +12,18 @@
 .. image:: https://img.shields.io/badge/recipe-{{ cookiecutter.package_name }}-green.svg
         :target: https://anaconda.org/conda-forge/{{ cookiecutter.package_name }}
 
-.. image:: https://img.shields.io/travis/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}.svg
-        :target: https://travis-ci.org/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}
-
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.package_name | replace("_", "-") }}/badge/?version=latest
         :target: https://{{ cookiecutter.package_name | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-        :target: https://github.com/csdms/pymt
-        :alt: Code style: black
+.. image:: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/test.yml/badge.svg
+        :target: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/test.yml
+
+.. image:: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/flake8.yml/badge.svg
+        :target: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/flake8.yml
+
+.. image:: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/black.yml/badge.svg
+        :target: https://github.com/{{ cookiecutter.info.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/black.yml
 {%- endif %}
 
 


### PR DESCRIPTION
This PR contains a set of minor modifications to the `mcflugen/render-github-workflows` branch.

* Combined install of the build and library requirements in the Test action
* Only apply flake8 and black to the package directory
* Changed job name in Black action to "format"
* Used "args" instead of "black_args" in Black action
* Updated status badges in README