### PR TITLE
Add Python 3.10 to ci tests

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
-        os: [macos-latest]
+        python-version: ["3.9"]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -19,9 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,9 +20,8 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest]
-        # python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [macos-latest]
-        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -19,8 +19,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        # os: [ubuntu-latest, macos-latest]
+        # python-version: ["3.8", "3.9", "3.10"]
+        os: [macos-latest]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black
+flake8
+flake8-bugbear
+isort
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 black
 click
 gitpython
-mock
 pyyaml
 tomlkit
 isort>=5
-jinja2
 cookiecutter

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,20 @@ def read(filename):
         return fp.read()
 
 
+def read_requirements(filename):
+    return [line.strip() for line in read(filename).splitlines()]
+
+
 long_description = u"\n\n".join(
     [read("README.rst"), read("CREDITS.rst"), read("CHANGES.rst")]
 )
+
+install_requires = read_requirements("requirements.txt")
+extras_require = {
+    "tests": read_requirements("requirements-testing.txt"),
+    "docs": read_requirements("requirements-docs.txt"),
+    "dev": read_requirements("requirements-dev.txt"),
+}
 
 
 setup(
@@ -17,6 +28,7 @@ setup(
     version="0.3.9.dev0",
     description="Wrap bmi libraries with Python bindings",
     long_description=long_description,
+    python_requires=">=3.9",
     author="Eric Hutton",
     author_email="huttone@colorado.edu",
     url="https://github.com/csdms",
@@ -28,11 +40,13 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Code Generators",
     ],
     keywords=["bmi", "pymt"],
-    install_requires=open("requirements.txt", "r").read().splitlines(),
+    install_requires=install_requires,
+    extras_require=extras_require,
     packages=find_packages(),
     include_package_data=True,
     entry_points={"console_scripts": ["babelize=babelizer.cli:babelize"]},


### PR DESCRIPTION
This pull request adds Python 3.10 to the continuous integration tests and drops Python 3.8.