### PR TITLE
Reorganize the testing requirements

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install coverage[toml]
-          mamba install --file=requirements.txt --file=requirements-testing.txt
+          mamba install --file=requirements.txt --file=requirements-testing.txt --file=external/requirements.txt
           conda list
 
       - name: Install babelizer
@@ -84,7 +84,7 @@ jobs:
 
       - name: Test babelizer + language examples and generate coverage report
         run: |
-          pytest --cov=babelizer --cov-report=xml:./coverage.xml -vvv
+          pytest --cov=babelizer --cov-report=xml:./coverage.xml -vvv babelizer tests external/tests
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Read all about them in the `Basic Model Interface`_ documentation.
 Requirements
 ************
 
-The *babelizer* requires Python >=3.8.
+The *babelizer* requires Python >=3.9.
 
 
 Apart from Python, the *babelizer* has a number of other requirements, all of which
@@ -140,8 +140,15 @@ After downloading the the *babelizer* source code, run the following from
 *babelizer*'s top-level directory (the one that contains *setup.py*) to
 install *babelizer* into the current environment:
 
-  $ pip install -e .
+.. code:: bash
 
+    $ pip install -e .
+
+or using *conda*:
+
+.. code:: bash
+
+    $ conda install --file=requirements.txt -c conda-forge
 
 **********
 Input file

--- a/external/requirements.txt
+++ b/external/requirements.txt
@@ -1,0 +1,10 @@
+bmi-tester>=0.5.4
+bmi-c
+bmi-cxx
+bmi-fortran
+bmipy
+cmake
+c-compiler
+cxx-compiler
+fortran-compiler
+pkg-config

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,13 +1,3 @@
-bmi-tester>=0.5.4
-bmi-c
-bmi-cxx
-bmi-fortran
-bmipy
-cmake
-c-compiler
-cxx-compiler
-fortran-compiler
-pkg-config
 pytest
 pytest-cov
 pytest-datadir


### PR DESCRIPTION
This pull request reorganizes some of the testing requirements. The *requirements-testing.txt* file now only contains *pip*-installable packages that are used for testing the *babelizer* package. This means that `pip install "babelizer[tests]"` will work. The *external/requirements.txt* file contains *conda* packages needed for testing the different languages.