### PR TITLE
Add python 3.8 to the ci tests

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -19,7 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -42,6 +42,7 @@ jobs:
           conda list
 
       - name: Install build system
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
           mamba install cython numpy setuptools wheel
 

--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -19,8 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest]
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
@@ -41,6 +40,10 @@ jobs:
           pip install coverage[toml]
           mamba install --file=requirements.txt --file=requirements-testing.txt --file=external/requirements.txt
           conda list
+
+      - name: Install build system
+        run: |
+          mamba install cython numpy setuptools wheel
 
       - name: Install babelizer
         run: |

--- a/external/tests/test_c.py
+++ b/external/tests/test_c.py
@@ -12,7 +12,7 @@ from babelizer.cli import babelize
 
 
 extra_opts = []
-if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+if sys.platform.startswith("linux") and int(platform.python_version_tuple()[1]) <= 8:
     extra_opts += ["--no-build-isolation"]
 
 

--- a/external/tests/test_c.py
+++ b/external/tests/test_c.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
 import os
 import pathlib
+import platform
 import shutil
 import subprocess
+import sys
 
 from click.testing import CliRunner
 
 from babelizer.cli import babelize
+
+
+extra_opts = []
+if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+    extra_opts += ["--no-build-isolation"]
 
 
 def test_babelize_init_c(tmpdir, datadir):
@@ -22,7 +29,7 @@ def test_babelize_init_c(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", ".", "--no-build-isolation"],
+                ["pip", "install", "-e", "."] + extra_opts,
                 cwd="pymt_heat",
                 check=True,
                 text=True,

--- a/external/tests/test_c.py
+++ b/external/tests/test_c.py
@@ -22,7 +22,7 @@ def test_babelize_init_c(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", "."],
+                ["pip", "install", "-e", ".", "--no-build-isolation"],
                 cwd="pymt_heat",
                 check=True,
                 text=True,

--- a/external/tests/test_cxx.py
+++ b/external/tests/test_cxx.py
@@ -22,7 +22,7 @@ def test_babelize_init_cxx(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", "."],
+                ["pip", "install", "-e", ".", "--no-build-isolation"],
                 cwd="pymt_heat",
                 check=True,
                 text=True,

--- a/external/tests/test_cxx.py
+++ b/external/tests/test_cxx.py
@@ -12,7 +12,7 @@ from babelizer.cli import babelize
 
 
 extra_opts = []
-if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+if sys.platform.startswith("linux") and int(platform.python_version_tuple()[1]) <= 8:
     extra_opts += ["--no-build-isolation"]
 
 

--- a/external/tests/test_cxx.py
+++ b/external/tests/test_cxx.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
 import os
 import pathlib
+import platform
 import shutil
 import subprocess
+import sys
 
 from click.testing import CliRunner
 
 from babelizer.cli import babelize
+
+
+extra_opts = []
+if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+    extra_opts += ["--no-build-isolation"]
 
 
 def test_babelize_init_cxx(tmpdir, datadir):
@@ -22,7 +29,7 @@ def test_babelize_init_cxx(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", ".", "--no-build-isolation"],
+                ["pip", "install", "-e", "."] + extra_opts,
                 cwd="pymt_heat",
                 check=True,
                 text=True,

--- a/external/tests/test_fortran.py
+++ b/external/tests/test_fortran.py
@@ -22,7 +22,7 @@ def test_babelize_init_fortran(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", "."],
+                ["pip", "install", "-e", ".", "--no-build-isolation"],
                 cwd="pymt_heatf",
                 check=True,
                 text=True,

--- a/external/tests/test_fortran.py
+++ b/external/tests/test_fortran.py
@@ -12,7 +12,7 @@ from babelizer.cli import babelize
 
 
 extra_opts = []
-if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+if sys.platform.startswith("linux") and int(platform.python_version_tuple()[1]) <= 8:
     extra_opts += ["--no-build-isolation"]
 
 

--- a/external/tests/test_fortran.py
+++ b/external/tests/test_fortran.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
 import os
 import pathlib
+import platform
 import shutil
 import subprocess
+import sys
 
 from click.testing import CliRunner
 
 from babelizer.cli import babelize
+
+
+extra_opts = []
+if sys.platform.startswith("linux") and platform.python_version_tuple()[1] <= 8:
+    extra_opts += ["--no-build-isolation"]
 
 
 def test_babelize_init_fortran(tmpdir, datadir):
@@ -22,7 +29,7 @@ def test_babelize_init_fortran(tmpdir, datadir):
 
         try:
             result = subprocess.run(
-                ["pip", "install", "-e", ".", "--no-build-isolation"],
+                ["pip", "install", "-e", "."] + extra_opts,
                 cwd="pymt_heatf",
                 check=True,
                 text=True,

--- a/news/72.misc
+++ b/news/72.misc
@@ -1,0 +1,1 @@
+Added Python 3.8 to the continuous integration tests.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version="0.3.10.dev0",
     description="Wrap bmi libraries with Python bindings",
     long_description=long_description,
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     author="Eric Hutton",
     author_email="huttone@colorado.edu",
     url="https://github.com/csdms",


### PR DESCRIPTION
This pull request add Python 3.8 to our continuous integration tests.