### PR TITLE
Update package_license values in tests

### DIFF
--- a/external/tests/test_c/babel.toml
+++ b/external/tests/test_c/babel.toml
@@ -10,7 +10,7 @@ undef_macros = []
 github_username = "mcflugen"
 plugin_author = "Eric Hutton"
 plugin_author_email = "eric.hutton@colorado.edu"
-plugin_license = "MIT"
+plugin_license = "MIT License"
 summary = "PyMT plugin for heat model"
 
 [library.HeatBMI]

--- a/external/tests/test_cxx/babel.toml
+++ b/external/tests/test_cxx/babel.toml
@@ -10,7 +10,7 @@ undef_macros = []
 github_username = "mcflugen"
 plugin_author = "Eric Hutton"
 plugin_author_email = "eric.hutton@colorado.edu"
-plugin_license = "MIT"
+plugin_license = "MIT License"
 summary = "PyMT plugin for heat model"
 
 [library.HeatBMI]

--- a/external/tests/test_fortran/babel.toml
+++ b/external/tests/test_fortran/babel.toml
@@ -21,7 +21,7 @@ requirements = [""]
 github_username = "pymt-lab"
 package_author = "csdms"
 package_author_email = "csdms@colorado.edu"
-package_license = "MIT"
+package_license = "MIT License"
 summary = "PyMT plugin for heatf model"
 
 [ci]

--- a/external/tests/test_python/babel.toml
+++ b/external/tests/test_python/babel.toml
@@ -21,7 +21,7 @@ requirements = []
 github_username = "csdms"
 package_author = "CSDMS"
 package_author_email = "csdms@colorado.edu"
-package_license = "MIT"
+package_license = "MIT License"
 summary = "PyMT component for the heatpy model"
 
 [ci]


### PR DESCRIPTION
This PR updates the *babel.toml* files used in the babelization tests for the four BMI examples (C, C++, Fortran, Python), making sure that the value of the `package_license` attribute matches one of the possibilities in the *babelizer/data/cookiecutter.json* file.

These changes are relevant for #74.

I also updated the bmi-example-python submodule to pull in recent changes.