### PR TITLE
Update sdist contents

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,23 +1,19 @@
 include *.rst
 include requirements*.txt
 include Makefile
-exclude appveyor.yml
 exclude .gitmodules
 exclude .readthedocs.yaml
-exclude external/bmi-example-c/.git
-exclude external/bmi-example-cxx/.git
-exclude external/bmi-example-fortran/.git
-exclude external/bmi-example-python/.git
 recursive-include babelizer/data *
 recursive-exclude docs *
 recursive-exclude paper *
+recursive-include tests *
 recursive-include external/bmi-example-c *
 recursive-include external/bmi-example-cxx *
 recursive-include external/bmi-example-fortran *
 recursive-include external/bmi-example-python *
-recursive-include tests *.py
-recursive-include tests *.toml
-recursive-include tests *.txt
-recursive-include tests *.cfg
-recursive-include tests *.yaml
-recursive-exclude recipe *
+recursive-include external/tests *
+include external/requirements.txt
+exclude external/bmi-example-c/.git*
+exclude external/bmi-example-cxx/.git*
+exclude external/bmi-example-fortran/.git*
+exclude external/bmi-example-python/.git*

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ docs: ## generate Sphinx HTML documentation, including API docs
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
+test-release: dist ## package and upload a release to TestPyPI
+	twine upload --repository testpypi dist/*
+
 release: dist ## package and upload a release
 	twine upload dist/*
 

--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,12 @@ servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: dist ## package and upload a release
-	twine check dist/*
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package
 	python -m build
 	ls -l dist
+	twine check dist/*
 
 install: clean ## install the package to the active Python's site-packages
 	pip install -e .

--- a/news/81.misc
+++ b/news/81.misc
@@ -1,0 +1,1 @@
+Updated manifest file for building source distribution.


### PR DESCRIPTION
This minor PR updates what files go into the `babelizer` source distribution--there were some stale entries, and some new files needed to be included. I also added a rule to the Makefile to upload to TestPyPI.

These changes partially address #80. 