### PR TITLE
Update default license to pass open_source_license check

### DIFF
--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -332,7 +332,7 @@ def _gather_input(
         "package_author_email": email
         or ask("Babelizing author email", default="csdms@colorado.edu"),
         "package_license": license
-        or ask("License to use for the babelized project", default="MIT"),
+        or ask("License to use for the babelized project", default="MIT License"),
         "summary": summary
         or ask("Brief description of what the library does", default=""),
     }

--- a/news/85.misc
+++ b/news/85.misc
@@ -1,0 +1,2 @@
+
+Changed the default license from "MIT" to "MIT License".


### PR DESCRIPTION
Currently the default `package_license` that is generated by `babelize generate` is "MIT". However, this results in a `ValueError` when you use the generated toml file because the valid choices are `['MIT License', 'BSD License', 'ISC License', 'Apache Software License 2.0', 'GNU General Public License v3', 'Not open source']`. Here I've simply changed the default to "MIT License" to be compliant.