### PR TITLE
Remove yaml formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
   - id: isort
     files: \.py$
     exclude: ^babelizer/data
+    args: [--force-single-line-imports]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -142,7 +142,7 @@ def update(template, quiet, verbose):
         metadata_path = None
 
     if not metadata_path:
-        err("this does not appear to be a babelized folder (missing 'babel.yaml')")
+        err("this does not appear to be a babelized folder (missing 'babel.toml')")
         raise click.Abort()
 
     template = template or str(importlib_resources.files("babelizer") / "data")

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -15,11 +15,14 @@ if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
 else:  # pragma: no cover (<PY312)
     import importlib_resources
 
-
-from .errors import OutputDirExistsError, ScanError, SetupPyError, ValidationError
+from .errors import OutputDirExistsError
+from .errors import ScanError
+from .errors import SetupPyError
+from .errors import ValidationError
 from .metadata import BabelMetadata
 from .render import render
-from .utils import get_setup_py_version, save_files
+from .utils import get_setup_py_version
+from .utils import save_files
 
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)

--- a/babelizer/metadata.py
+++ b/babelizer/metadata.py
@@ -14,7 +14,8 @@ if sys.version_info >= (3, 11):  # pragma: no cover (PY11+)
 else:  # pragma: no cover (<PY311)
     import tomli as tomllib
 
-from .errors import ScanError, ValidationError
+from .errors import ScanError
+from .errors import ValidationError
 
 
 def validate_dict(meta, required=None, optional=None):

--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -20,7 +20,8 @@ if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
 else:  # pragma: no cover (<PY312)
     import importlib_resources
 
-from .errors import OutputDirExistsError, RenderError
+from .errors import OutputDirExistsError
+from .errors import RenderError
 
 
 def render(plugin_metadata, output, template=None, clobber=False, version="0.1"):

--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -8,10 +8,13 @@ import sys
 import black as blk
 import git
 import isort
-import tomlkit as toml
 from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
 
+if sys.version_info >= (3, 11):  # pragma: no cover (PY11+)
+    import tomllib
+else:  # pragma: no cover (<PY311)
+    import tomli as tomllib
 if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
     import importlib.resources as importlib_resources
 else:  # pragma: no cover (<PY312)
@@ -160,7 +163,7 @@ def prettify_python(path_to_repo):
     """
     path_to_repo = pathlib.Path(path_to_repo)
     with open(path_to_repo / "babel.toml") as fp:
-        meta = toml.parse(fp.read())
+        meta = tomllib.loads(fp.read())
     module_name = meta["package"]["name"]
 
     files_to_fix = [

--- a/babelizer/utils.py
+++ b/babelizer/utils.py
@@ -3,7 +3,8 @@
 import pathlib
 import subprocess
 import sys
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
+from contextlib import suppress
 
 from .errors import SetupPyError
 

--- a/news/89.misc
+++ b/news/89.misc
@@ -1,0 +1,3 @@
+
+Removed the ability of the *babelizer* to write its config file in
+*yaml* format. We switched to using *toml* a while ago.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,10 @@ dependencies = [
     "gitpython",
     "importlib-resources; python_version < '3.12'",
     "isort>=5",
-    "logoizer @ git+https://github.com/mcflugen/logoizer",
+    "logoizer@ git+https://github.com/mcflugen/logoizer",
     "pyyaml",
-    "tomlkit",
+    "tomli-w",
+    "tomli; python_version < '3.11'",
 ]
 dynamic = [
     "readme",


### PR DESCRIPTION
This pull request removes the ability of the *babelizer* to write config files formatted as *yaml*. It can still read legacy yaml files, just not create new ones. We've been using *toml* as our config file format for a while so it didn't seem like we needed to continue supporting *yaml*.

I've dropped *tomlkit* in favor of *tomllib* (for Python 3.11+, and *tomli* for 3.10) for loading config files and *tomli-w* for writing config files. *tomlkit* was overkill for what we were using it for.