### PR TITLE
Remove options for babelize generate command

### DIFF
--- a/babelizer/__init__.py
+++ b/babelizer/__init__.py
@@ -1,5 +1,5 @@
 """The *babelizer*."""
 
-from ._version import __version__
+from babelizer._version import __version__
 
 __all__ = ["__version__"]

--- a/babelizer/__main__.py
+++ b/babelizer/__main__.py
@@ -1,0 +1,8 @@
+"""The babelize command."""
+
+from __future__ import annotations
+
+from babelizer.cli import babelize
+
+if __name__ == "__main__":
+    raise SystemExit(babelize())

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -26,8 +26,6 @@ from babelizer.utils import save_files
 
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)
-# ask = partial(click.prompt, show_default=True, err=True)
-yes = partial(click.confirm, show_default=True, err=True)
 
 
 class BabelizerAbort(click.Abort):
@@ -210,7 +208,7 @@ def update(template, quiet, verbose, set_version):
 @babelize.command()
 def sample_config():
     """Generate the babelizer configuration file."""
-    sample_config()
+    print_sample_config()
 
 
 def _get_dir_contents(base, trunk=None):
@@ -293,7 +291,7 @@ os = [
 """
 
 
-def sample_config() -> int:
+def print_sample_config() -> int:
     """Print a sample babelizer configuration file."""
     print(SAMPLE_CONFIG, end="")
     return 0

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -133,7 +133,10 @@ def init(meta, template, quiet, verbose, package_version):
     default=None,
     help="Location of cookiecutter template",
 )
-def update(template, quiet, verbose):
+@click.option(
+    "--set-version", default=None, help="Set the version of the updated package"
+)
+def update(template, quiet, verbose, set_version):
     """Update an existing babelized project."""
     package_path = pathlib.Path(".").resolve()
 
@@ -159,10 +162,16 @@ def update(template, quiet, verbose):
         raise BabelizerAbort(error)
 
     try:
-        version = get_setup_py_version()
+        version = set_version or get_setup_py_version()
     except SetupPyError as error:
         raise BabelizerAbort(
-            os.linesep.join(["the setup.py of this package has an error:", f"{error}"])
+            os.linesep.join(
+                [
+                    "the setup.py of this package has an error:",
+                    f"{error}"
+                    "unable to get package's version. Try using the '--set-version' option",
+                ]
+            )
         )
 
     out(f"re-rendering {package_path}")

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -15,14 +15,14 @@ if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
 else:  # pragma: no cover (<PY312)
     import importlib_resources
 
-from .errors import OutputDirExistsError
-from .errors import ScanError
-from .errors import SetupPyError
-from .errors import ValidationError
-from .metadata import BabelMetadata
-from .render import render
-from .utils import get_setup_py_version
-from .utils import save_files
+from babelizer.errors import OutputDirExistsError
+from babelizer.errors import ScanError
+from babelizer.errors import SetupPyError
+from babelizer.errors import ValidationError
+from babelizer.metadata import BabelMetadata
+from babelizer.render import render
+from babelizer.utils import get_setup_py_version
+from babelizer.utils import save_files
 
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -208,7 +208,7 @@ def update(template, quiet, verbose, set_version):
 
 
 @babelize.command()
-def generate():
+def sample_config():
     """Generate the babelizer configuration file."""
     sample_config()
 

--- a/babelizer/cli.py
+++ b/babelizer/cli.py
@@ -199,219 +199,9 @@ def update(template, quiet, verbose):
 
 
 @babelize.command()
-@click.option(
-    "--prompt",
-    is_flag=True,
-    help="Prompt the user for values",
-)
-@click.option(
-    "--package",
-    help="Name to use for the babelized package",
-)
-@click.option(
-    "--name",
-    help="Name of the babelized class",
-)
-@click.option(
-    "--email",
-    help="Contact email to use for the babelized package",
-)
-@click.option(
-    "--language",
-    help="Programming language of the library being babelized",
-    type=click.Choice(["c", "c++", "fortran", "python"], case_sensitive=False),
-)
-@click.option("--author", help="Babelizing author")
-@click.option(
-    "--username",
-    help="GitHub username or organization that will host the project",
-)
-@click.option(
-    "--license",
-    help="License to use for the babelized project",
-)
-@click.option(
-    "--summary",
-    help="Brief description of what the library does",
-)
-@click.option("--library", help="Name of the BMI library to wrap", default=None)
-@click.option(
-    "--header", help="Name of the header file declaring the BMI class", default=None
-)
-@click.option(
-    "--entry-point", help="Name of the BMI entry point into the library", default=None
-)
-@click.option("--requirement", help="Required libraries", multiple=True, default=None)
-@click.option("--python-version", help="Supported Python versions", default="3.9")
-@click.option(
-    "--os-name", help="Supported operating systems", default="linux,mac,windows"
-)
-def generate(
-    prompt,
-    package,
-    name,
-    email,
-    language,
-    author,
-    username,
-    license,
-    summary,
-    library,
-    header,
-    entry_point,
-    requirement,
-    python_version,
-    os_name,
-):
+def generate():
     """Generate the babelizer configuration file."""
-    meta = _gather_input(
-        prompt=prompt,
-        package=package,
-        name=name,
-        email=email,
-        language=language,
-        author=author,
-        username=username,
-        license=license,
-        summary=summary,
-        library=library,
-        header=header,
-        entry_point=entry_point,
-        requirement=requirement,
-        python_version=python_version,
-        os_name=os_name,
-    )
-
-    print(BabelMetadata(**meta).format(fmt="toml"))
-
-
-def _gather_input(
-    prompt=False,
-    package=None,
-    name=None,
-    email=None,
-    language=None,
-    author=None,
-    username=None,
-    license=None,
-    summary=None,
-    library=None,
-    header=None,
-    entry_point=None,
-    requirement=None,
-    python_version=None,
-    os_name=None,
-):
-    """Gather input either from command-line option, default, or user prompt.
-
-    If a value is not ``None``, that means it was provided on the command
-    line and so its value will be used. Otherwise, depending on
-    the value of ``no_input``, either a default value is used or
-    the user will be prompted for a value.
-    """
-    if prompt:
-        ask = partial(click.prompt, show_default=True, err=True)
-    else:
-
-        def ask(text, default=None, **kwds):
-            return default
-
-    def _split_if_str(val, sep=","):
-        return val.split(sep) if isinstance(val, str) else val
-
-    python_version = _split_if_str(python_version)
-    os_name = _split_if_str(os_name)
-
-    def ask_until_done(text):
-        answers = []
-        while (answer := ask(text, default="done")) != "done":
-            answers.append(answer)
-        return answers
-
-    package = {
-        "name": package or ask("Name to use for the babelized package", default=""),
-        "requirements": requirement or ask_until_done("Requirement"),
-    }
-    info = {
-        "github_username": username
-        or ask(
-            "GitHub username or organization that will host the project",
-            default="pymt-lab",
-        ),
-        "package_author": author or ask("Babelizing author", default="csdms"),
-        "package_author_email": email
-        or ask("Babelizing author email", default="csdms@colorado.edu"),
-        "package_license": license
-        or ask("License to use for the babelized project", default="MIT License"),
-        "summary": summary
-        or ask("Brief description of what the library does", default=""),
-    }
-
-    language = language or ask(
-        "Programming language of the library being babelized",
-        show_choices=["c", "c++", "fortran", "python"],
-        default="c",
-    )
-
-    ci = {
-        "os": os_name
-        or ask_until_done(
-            "Supported operating system",
-            show_choices=["linux", "mac", "windows", "all"],
-            default="all",
-        ),
-        "python_version": python_version
-        or ask_until_done(
-            "Supported python version",
-            show_choices=["3.7", "3.8", "3.9"],
-            default="3.9",
-        ),
-    }
-
-    libraries = {}
-    if (not prompt) or any(x is not None for x in (name, library, header, entry_point)):
-        babelized_class = name or ask("Name of babelized class", default="<name>")
-        libraries[babelized_class] = {
-            "language": language,
-            "library": library
-            or ask(f"[{babelized_class}] Name of library to babelize", default=""),
-            "header": header
-            or (
-                ask(
-                    f"[{babelized_class}] Name of header file containing BMI class ",
-                    default="",
-                )
-                if language != "python"
-                else "__UNUSED__"
-            ),
-            "entry_point": entry_point
-            or ask(f"[{babelized_class}] Name of BMI class ", default=""),
-        }
-    else:
-        while 1:
-            babelized_class = ask("Name of babelized class")
-            libraries[babelized_class] = {
-                "language": language,
-                "library": ask(f"[{babelized_class}] Name of library to babelize"),
-                "header": (
-                    ask(
-                        f"[{babelized_class}] Name of header file containing BMI class "
-                    )
-                    if language != "python"
-                    else "__UNUSED__"
-                ),
-                "entry_point": ask(f"[{babelized_class}] Name of BMI class "),
-            }
-            if not yes("Add another library?", default=False):
-                break
-
-    return {
-        "library": libraries,
-        "package": package,
-        "info": info,
-        "build": {},
-        "ci": ci,
-    }
+    sample_config()
 
 
 def _get_dir_contents(base, trunk=None):
@@ -442,6 +232,62 @@ def _generated_files(babel_metadata, template=None, version="0.1"):
             version=version,
         )
         return _get_dir_contents(new_folder, trunk=new_folder)
+
+
+SAMPLE_CONFIG = """\
+# See https://babelizer.readthedocs.io/ for more information
+
+# Describe the library being wrapped.
+[library.Monorail]
+language = "c"
+library = "bmimonorail"
+header = "monorail.h"
+entry_point = "register_monorail"
+
+# Describe compiler options need to build the library being
+# wrapped.
+[build]
+undef_macros = []
+define_macros = []
+libraries = []
+library_dirs = []
+include_dirs = []
+extra_compile_args = []
+
+# Describe the newly wrapped package.
+[package]
+name = "springfield_monorail"
+requirements = ["three_million_dollars"]
+
+[info]
+github_username = "lyle-lanley"
+package_author = "Lyle Lanley"
+package_author_email = "lyle@monorail.com"
+package_license = "MIT License"
+summary = '''
+Well, sir, there's nothing on Earth like a genuine,
+bona fide, electrified, six-car monorail. What'd I say?
+Monorail! What's it called? Monorail! That's right! Monorail!
+'''
+
+[ci]
+python_version = [
+    "3.10",
+    "3.11",
+    "3.12",
+]
+os = [
+    "linux",
+    "mac",
+    "windows",
+]
+"""
+
+
+def sample_config() -> int:
+    """Print a sample babelizer configuration file."""
+    print(SAMPLE_CONFIG, end="")
+    return 0
 
 
 if __name__ == "__main__":

--- a/babelizer/errors.py
+++ b/babelizer/errors.py
@@ -1,13 +1,15 @@
 """Exceptions raised by the *babelizer*."""
 
+from __future__ import annotations
+
 
 class BabelizeError(Exception):
     """An exception that the babelizer can handle and show to the user."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         self._message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Render a user-readable error message."""
         return self._message
 

--- a/babelizer/metadata.py
+++ b/babelizer/metadata.py
@@ -14,8 +14,8 @@ if sys.version_info >= (3, 11):  # pragma: no cover (PY11+)
 else:  # pragma: no cover (<PY311)
     import tomli as tomllib
 
-from .errors import ScanError
-from .errors import ValidationError
+from babelizer.errors import ScanError
+from babelizer.errors import ValidationError
 
 
 def validate_dict(meta, required=None, optional=None):

--- a/babelizer/render.py
+++ b/babelizer/render.py
@@ -20,8 +20,8 @@ if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
 else:  # pragma: no cover (<PY312)
     import importlib_resources
 
-from .errors import OutputDirExistsError
-from .errors import RenderError
+from babelizer.errors import OutputDirExistsError
+from babelizer.errors import RenderError
 
 
 def render(plugin_metadata, output, template=None, clobber=False, version="0.1"):

--- a/babelizer/utils.py
+++ b/babelizer/utils.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import contextmanager
 from contextlib import suppress
 
-from .errors import SetupPyError
+from babelizer.errors import SetupPyError
 
 
 def execute(args):

--- a/babelizer/utils.py
+++ b/babelizer/utils.py
@@ -1,8 +1,11 @@
 """Utility functions used by the babelizer."""
 
+from __future__ import annotations
+
 import pathlib
 import subprocess
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextlib import suppress
 
@@ -36,7 +39,7 @@ def setup_py(*args):
     return [sys.executable, "setup.py"] + list(args)
 
 
-def get_setup_py_version():
+def get_setup_py_version() -> str | None:
     """Get babelized package version.
 
     Returns
@@ -64,7 +67,7 @@ def get_setup_py_version():
 
 
 @contextmanager
-def save_files(files):
+def save_files(files: Iterator[str]):
     """Generate repository files through a context.
 
     Parameters

--- a/news/91.misc
+++ b/news/91.misc
@@ -1,0 +1,4 @@
+
+Simplified the *babelize generate* command so that it no longer accepts
+any command line options or prompts the user for input. Instead, it
+prints a sample *babelize* config file.

--- a/news/91.misc
+++ b/news/91.misc
@@ -1,4 +1,4 @@
 
-Simplified the *babelize generate* command so that it no longer accepts
-any command line options or prompts the user for input. Instead, it
-prints a sample *babelize* config file.
+Renamed *babelize generate* to *babelize sample-config* and simplified
+the command so that it no longer accepts command line options or
+prompts the user for input. Instead, it prints a sample *babelize* config file.

--- a/noxfile.py
+++ b/noxfile.py
@@ -126,6 +126,7 @@ def test_cli(session: nox.Session) -> None:
     session.run("babelize", "init", "--help")
     session.run("babelize", "update", "--help")
     session.run("babelize", "generate", "--help")
+    session.run("babelize", "generate")
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -125,8 +125,16 @@ def test_cli(session: nox.Session) -> None:
     session.run("babelize", "--help")
     session.run("babelize", "init", "--help")
     session.run("babelize", "update", "--help")
-    session.run("babelize", "generate", "--help")
-    session.run("babelize", "generate")
+    session.run("babelize", "sample-config", "--help")
+
+    with session.chdir(session.create_tmp()):
+        with open("babel.toml", "w") as fp:
+            session.run("babelize", "sample-config", stdout=fp)
+        new_folder = session.run(
+            "babelize", "init", "babel.toml", "--quiet", silent=True
+        ).strip()
+        with session.chdir(new_folder):
+            session.run("babelize", "update", "--set-version=0.1.1")
 
 
 @nox.session

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_defaults():
 
 def test_generate_help():
     runner = CliRunner()
-    result = runner.invoke(babelize, ["generate", "--help"])
+    result = runner.invoke(babelize, ["sample-config", "--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.output
 
@@ -57,13 +57,13 @@ def test_update_help():
 
 def test_generate_noargs():
     runner = CliRunner()
-    result = runner.invoke(babelize, ["generate"])
+    result = runner.invoke(babelize, ["sample-config"])
     assert result.exit_code == 0
 
 
 def test_generate_gives_valid_toml():
     runner = CliRunner()
-    result = runner.invoke(babelize, ["generate"])
+    result = runner.invoke(babelize, ["sample-config"])
     assert result.exit_code == 0
 
     config = tomllib.loads(result.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,11 @@
 """Test the babelizer command-line interface"""
 
-import tomllib
+import sys
+
+if sys.version_info >= (3, 11):  # pragma: no cover (PY11+)
+    import tomllib
+else:  # pragma: no cover (<PY311)
+    import tomli as tomllib
 
 from click.testing import CliRunner
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 """Test the babelizer command-line interface"""
 
+import tomllib
+
 from click.testing import CliRunner
 
 from babelizer.cli import babelize
+from babelizer.metadata import BabelMetadata
 
 
 def test_help():
@@ -51,6 +54,15 @@ def test_generate_noargs():
     runner = CliRunner()
     result = runner.invoke(babelize, ["generate"])
     assert result.exit_code == 0
+
+
+def test_generate_gives_valid_toml():
+    runner = CliRunner()
+    result = runner.invoke(babelize, ["generate"])
+    assert result.exit_code == 0
+
+    config = tomllib.loads(result.output)
+    BabelMetadata.validate(config)
 
 
 def test_init_noargs():


### PR DESCRIPTION
This pull requests simplifies the `babelize generate` command by removing all command line options and no longer prompting a user for input. Instead, it just prints a sample *babelize* config file for a user to edit. The options and prompts added a lot of extra code for little benefit.