### PR TITLE
Fix failing docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,3 @@ python:
     - requirements: requirements.txt
     - method: pip
       path: .
-  system_packages: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,12 +1,17 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -e -force --no-toc --module-first -o docs/source/api babelizer
+
 sphinx:
   builder: html
   configuration: docs/source/conf.py
   fail_on_warning: false
-
-formats:
-  - htmlzip
 
 python:
   install:
@@ -15,11 +20,3 @@ python:
     - method: pip
       path: .
   system_packages: false
-
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.9"
-  jobs:
-    pre_build:
-      - sphinx-apidoc -e -force --no-toc --module-first -o docs/source/api babelizer

--- a/news/93.doc
+++ b/news/93.doc
@@ -1,0 +1,3 @@
+
+Removed the the now-obsolete `system_packages` configuration key that was
+causing builds to fail on rtfd.io.


### PR DESCRIPTION
This PR contains one small fix: removing the now invalid `system_packages` setting from the rtfd configuration.